### PR TITLE
Produce cleaner dmg volume name by running macdeployqt with local path

### DIFF
--- a/cmake/macdeployqt.cmake
+++ b/cmake/macdeployqt.cmake
@@ -13,7 +13,7 @@ find_program(MACDEPLOYQT_EXECUTABLE macdeployqt HINTS "${_qt_bin_dir}")
 function(macdeployqt target)
     add_custom_command(TARGET ${target} POST_BUILD
         COMMAND "${MACDEPLOYQT_EXECUTABLE}"
-            \"$<TARGET_FILE_DIR:${target}>/../..\"
+            \"${target}.app\"
             -always-overwrite -dmg
         COMMENT "Deploying Qt..."
     )


### PR DESCRIPTION
See https://doc.qt.io/qt-5/macos-deployment.html#volume-name: "The volume name of a disk image (the text displayed in the window title of an opened .dmg file) created with -dmg is based on the path to the application when macdeployqt is run."