### PR TITLE
Reduce number of interface elements: clean-up

### DIFF
--- a/MarianInterface.h
+++ b/MarianInterface.h
@@ -25,7 +25,7 @@ public:
     ~MarianInterface();
     const QString mymodel;
 signals:
-    void translationReady(QString);
+    void translationReady(QString translation);
 };
 
 #endif // MARIANINTERFACE_H

--- a/ModelManager.cpp
+++ b/ModelManager.cpp
@@ -15,12 +15,6 @@
 #include <archive.h>
 #include <archive_entry.h>
 
-const int ModelManager::kColumnName = 0;
-const int ModelManager::kColumnShortName = 1;
-const int ModelManager::kColumnPathName = 2;
-const int ModelManager::kColumnType = 3;
-
-const int ModelManager::kLastColumn = 3;
 
 ModelManager::ModelManager(QObject *parent)
     : QAbstractTableModel(parent)
@@ -337,13 +331,13 @@ QVariant ModelManager::data(QModelIndex const &index, int role) const {
                 return QVariant::fromValue(model);
             case Qt::DisplayRole:
                 switch (index.column()) {
-                    case kColumnName:
+                    case ModelManager::Column::Name:
                         return model.name;
-                    case kColumnShortName:
+                    case Column::ShortName:
                         return model.shortName;
-                    case kColumnPathName:
+                    case Column::PathName:
                         return model.path;
-                    case kColumnType:
+                    case Column::Type:
                         return model.type;
                     // Intentional fall-through for default
                 }
@@ -358,13 +352,13 @@ QVariant ModelManager::data(QModelIndex const &index, int role) const {
                 return QVariant::fromValue(model);
             case Qt::DisplayRole:
                 switch (index.column()) {
-                    case kColumnName:
+                    case Column::Name:
                         return model.name;
-                    case kColumnShortName:
+                    case Column::ShortName:
                         return model.code;
-                    case kColumnPathName:
+                    case Column::PathName:
                         return model.url;
-                    case kColumnType:
+                    case Column::Type:
                         return QString();
                     // Intentional fall-through for default
                 }
@@ -384,13 +378,13 @@ QVariant ModelManager::headerData(int section, Qt::Orientation orientation, int 
         return QVariant();
 
     switch (section) {
-        case kColumnName:
+        case Column::Name:
             return "Name";
-        case kColumnShortName:
+        case Column::ShortName:
             return "Short name";
-        case kColumnPathName:
+        case Column::PathName:
             return "Path";
-        case kColumnType:
+        case Column::Type:
             return "Type";
         default:
             return QVariant();
@@ -400,7 +394,7 @@ QVariant ModelManager::headerData(int section, Qt::Orientation orientation, int 
 int ModelManager::columnCount(QModelIndex const &index) const {
     Q_UNUSED(index);
 
-    return kLastColumn + 1;
+    return kColumnCount;
 }
 
 int ModelManager::rowCount(QModelIndex const &index) const {

--- a/ModelManager.cpp
+++ b/ModelManager.cpp
@@ -301,12 +301,17 @@ QList<LocalModel> ModelManager::installedModels() const {
     return localModels_;
 }
 
+QList<RemoteModel> ModelManager::remoteModels() const {
+    return remoteModels_;
+}
+
 QList<RemoteModel> ModelManager::availableModels() const {
     QList<RemoteModel> filtered;
     for (auto &&model : remoteModels_) {
         bool installed = false;
 
         for (auto &&localModel : localModels_) {
+            // TODO: matching by name might not be very robust
             if (localModel.name == model.name) {
                 installed = true;
                 break;

--- a/ModelManager.cpp
+++ b/ModelManager.cpp
@@ -321,8 +321,6 @@ QList<RemoteModel> ModelManager::availableModels() const {
 }
 
 QVariant ModelManager::data(QModelIndex const &index, int role) const {
-    Q_UNUSED(role);
-
     if (index.row() <= localModels_.size()) {
         LocalModel const &model = localModels_[index.row()];
 
@@ -371,7 +369,6 @@ QVariant ModelManager::data(QModelIndex const &index, int role) const {
 }
 
 QVariant ModelManager::headerData(int section, Qt::Orientation orientation, int role) const {
-    Q_UNUSED(role);
     Q_UNUSED(orientation);
 
     if (role != Qt::DisplayRole)

--- a/ModelManager.h
+++ b/ModelManager.h
@@ -34,6 +34,7 @@ public:
     void writeModel(QString filename, QByteArray data);
 
     QList<LocalModel> installedModels() const;
+    QList<RemoteModel> remoteModels() const;
     QList<RemoteModel> availableModels() const; // remote - local
 
     enum Column {

--- a/ModelManager.h
+++ b/ModelManager.h
@@ -36,16 +36,18 @@ public:
     QList<LocalModel> installedModels() const;
     QList<RemoteModel> availableModels() const; // remote - local
 
+    enum Column {
+        Name,
+        ShortName,
+        PathName,
+        Type
+    };
+    Q_ENUM(Column);
+
     virtual QVariant data(QModelIndex const &, int role = Qt::DisplayRole) const;
     virtual QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const;
     virtual int columnCount(QModelIndex const & = QModelIndex()) const;
     virtual int rowCount(QModelIndex const & = QModelIndex()) const;
-
-    static const int kColumnName;
-    static const int kColumnShortName;
-    static const int kColumnPathName;
-    static const int kColumnType;
-    static const int kLastColumn;
 
     translateLocally::marianSettings& getSettings() {
         return settings_;
@@ -70,6 +72,8 @@ private:
     translateLocally::marianSettings settings_; // @TODO to be initialised by reading saved settings from disk
 
     QNetworkAccessManager *nam_;
+
+    constexpr static int kColumnCount = 4;
 
 signals:
     void newModelAdded(int index);

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -89,9 +89,6 @@ void MainWindow::on_inputBox_textChanged() {
     QString inputText = ui_->inputBox->toPlainText();
     inactivityTimer_.stop();
 
-    if (inputText.isEmpty())
-        return;
-
     // Remove the last word, because it is likely incomplete
     auto lastSpace = inputText.lastIndexOf(" ");
     
@@ -198,15 +195,7 @@ void MainWindow::translate(QString const &text) {
     ui_->translateAction->setEnabled(false); //Disable the translate button before the translation finishes
     ui_->translateButton->setEnabled(false);
     if (translator_) {
-        if (!text.isEmpty()) {
-            ui_->outputBox->setText("Translating, please wait...");
-            this->repaint(); // Force update the UI before the translation starts so that it can show the previous text
-            translator_->translate(text);
-        } else {
-            ui_->outputBox->setText("");
-            ui_->translateAction->setEnabled(true);
-            ui_->translateButton->setEnabled(true);
-        }
+        translator_->translate(text);
     } else {
         popupError("You need to download a translation model first. Do that with the interface on the right.");
     }    
@@ -235,11 +224,12 @@ void MainWindow::resetTranslator(QString dirname) {
     ui_->translateButton->setEnabled(true);
 
     // Set up the connection to the translator
-    connect(translator_.get(), &MarianInterface::translationReady, this, [&](QString translation){ui_->outputBox->setText(translation);
-                                                                                                  ui_->localModels->setEnabled(true); // Re-enable model changing
-                                                                                                  ui_->translateAction->setEnabled(true); // Re-enable button after translation is done
-                                                                                                  ui_->translateButton->setEnabled(true);
-                                                                                                 });
+    connect(translator_.get(), &MarianInterface::translationReady, this, [&](QString translation) {
+        ui_->outputBox->setText(translation);
+        ui_->localModels->setEnabled(true); // Re-enable model changing
+        ui_->translateAction->setEnabled(true); // Re-enable button after translation is done
+        ui_->translateButton->setEnabled(true);
+    });
 
     translate();
 }

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -149,11 +149,13 @@ void MainWindow::updateLocalModels() {
     }
 
     // Add any models available for download
-    if (!models_.availableModels().empty()) {
+    if (models_.remoteModels().empty()) {
+        ui_->localModels->addItem("Download models…", QVariant::fromValue(kActionFetchRemoteModels));
+    } else if (models_.availableModels().empty()) {
+        ui_->localModels->addItem("No other models available online");
+    } else {
         for (auto &&model : models_.availableModels())
             ui_->localModels->addItem(model.name, QVariant::fromValue(model));
-    } else {
-        ui_->localModels->addItem("Download models…", QVariant::fromValue(kActionFetchRemoteModels));
     }
 }
 

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -29,6 +29,11 @@ public:
     void downloadProgress(qint64 ist, qint64 max);
     void updateModelSettings(size_t memory, size_t cores);
 
+    enum Action {
+        FetchRemoteModels
+    };
+    Q_ENUM(Action);
+
 private slots:
     void on_inputBox_textChanged();
 
@@ -54,6 +59,7 @@ private:
     std::unique_ptr<MarianInterface> translator_;
     void resetTranslator(QString dirname);
     void showDownloadPane(bool visible);
+    void downloadModel(RemoteModel model);
 
     // Keep track of the models
     QStringList urls_;
@@ -70,7 +76,5 @@ private:
 
     QTimer inactivityTimer_;
     QString translationInput_;
-
-    static const QString kActionFetchRemoteModels;
 };
 #endif // MAINWINDOW_H

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -34,16 +34,23 @@ public:
     };
     Q_ENUM(Action);
 
+public slots:
+    void setTranslateImmediately(bool);
+
 private slots:
     void on_inputBox_textChanged();
 
     void on_translateAction_triggered();
+
+    void on_translateButton_clicked();
 
     void on_fontAction_triggered();
 
     void on_actionTranslator_Settings_triggered();
 
     void on_localModels_activated(int index);
+
+    void on_actionTranslateImmediately_toggled(bool);
 
     void popupError(QString error);
 
@@ -76,5 +83,7 @@ private:
 
     QTimer inactivityTimer_;
     QString translationInput_;
+
+    bool translateImmediately_;
 };
 #endif // MAINWINDOW_H

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -64,6 +64,47 @@
     <item row="0" column="0">
      <layout class="QVBoxLayout" name="verticalLayout">
       <item>
+       <widget class="QWidget" name="modelPane" native="true">
+        <layout class="QHBoxLayout" name="horizontalLayout">
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <item>
+          <widget class="QComboBox" name="localModels">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>196</width>
+             <height>0</height>
+            </size>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="translateButton">
+           <property name="text">
+            <string>Translate</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item>
        <widget class="QWidget" name="downloadPane" native="true">
         <layout class="QHBoxLayout" name="horizontalLayout_2">
          <property name="leftMargin">
@@ -102,16 +143,6 @@
         </layout>
        </widget>
       </item>
-      <item>
-       <widget class="QComboBox" name="localModels">
-        <property name="minimumSize">
-         <size>
-          <width>196</width>
-          <height>0</height>
-         </size>
-        </property>
-       </widget>
-      </item>
      </layout>
     </item>
    </layout>
@@ -129,15 +160,20 @@
     <property name="title">
      <string>Edit</string>
     </property>
-    <addaction name="translateAction"/>
-    <addaction name="fontAction"/>
     <addaction name="actionTranslator_Settings"/>
+    <addaction name="actionTranslateImmediately"/>
+    <addaction name="translateAction"/>
+    <addaction name="separator"/>
+    <addaction name="fontAction"/>
    </widget>
    <addaction name="menuEdit"/>
   </widget>
   <action name="translateAction">
    <property name="text">
     <string>Translate</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+Return</string>
    </property>
   </action>
   <action name="fontAction">
@@ -148,6 +184,17 @@
   <action name="actionTranslator_Settings">
    <property name="text">
     <string>Translator Settings..</string>
+   </property>
+  </action>
+  <action name="actionTranslateImmediately">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="checked">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Translate as I type</string>
    </property>
   </action>
  </widget>


### PR DESCRIPTION
- Clean up `static const` code in favour of enums + constexpr
- Add menu item to disable *translate as you type* in favour of a plain old "translate!" button. On macOS cmd + enter also works to trigger translation. I assume on Linux/Windows this translates to super + enter.
- Make distinction between *no model list downloaded* and *no models available that you don't already have locally installed*.
- Clearing out the input text box now also properly clears out the translated output box
- Removed "Translating…" text that shows up in the translation output box for now as it was constantly overridden with partial translations. This should be replaced by a separate loading indicator. I'll open a separate issue to discuss this because there's plenty of options but none stand out to me as the obvious one. Update: #13 
