### PR TITLE
Add status bar with activity indicator

### DIFF
--- a/MarianInterface.cpp
+++ b/MarianInterface.cpp
@@ -57,7 +57,6 @@ void MarianInterface::translate(QString in) {
         // as we sent sentences to be translated. So let's make sure we haven't
         // been overtaken by a further progressed sentence before emitting the
         // translation.
-        // TODO: race condition on finished_?
         if (serial < finished_)
             return;
         

--- a/MarianInterface.cpp
+++ b/MarianInterface.cpp
@@ -61,10 +61,16 @@ void MarianInterface::translate(QString in) {
             return;
         
         finished_ = serial;
+
         emit translationReady(translation);
+
+        if (serial_ == finished_)
+            emit pendingChanged(false);
     };
 
-    std::thread mythread(translateAndSignal, in.toStdString(), ++serial_);
+    std::size_t serial = ++serial_;
+    emit pendingChanged(true);
+    std::thread mythread(translateAndSignal, in.toStdString(), serial);
     mythread.detach();
 }
 
@@ -74,3 +80,6 @@ MarianInterface::~MarianInterface() {
     spdlog::drop("valid");
 }
 
+bool MarianInterface::pending() const {
+    return serial_ == finished_;
+}

--- a/MarianInterface.h
+++ b/MarianInterface.h
@@ -2,6 +2,7 @@
 #define MARIANINTERFACE_H
 #include <QString>
 #include <QObject>
+#include <QAtomicInteger>
 #include <memory>
 #include "types.h"
 #include <thread>
@@ -17,8 +18,8 @@ class MarianInterface : public QObject {
     Q_OBJECT
 private:
     std::unique_ptr<marian::bergamot::Service> service_;
-    std::size_t serial_;
-    std::size_t finished_;
+    QAtomicInteger<std::size_t> serial_;
+    QAtomicInteger<std::size_t> finished_;
 public:
     MarianInterface(QString path_to_model_dir, translateLocally::marianSettings& settings, QObject * parent);
     void translate(QString in);

--- a/MarianInterface.h
+++ b/MarianInterface.h
@@ -25,8 +25,10 @@ public:
     void translate(QString in);
     ~MarianInterface();
     const QString mymodel;
+    bool pending() const;
 signals:
     void translationReady(QString translation);
+    void pendingChanged(bool isBusy);
 };
 
 #endif // MARIANINTERFACE_H

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -27,6 +27,8 @@ MainWindow::MainWindow(QWidget *parent)
     , network_(this)
 {
     ui_->setupUi(this);
+    ui_->statusbar->addPermanentWidget(ui_->pendingIndicator);
+    ui_->pendingIndicator->hide();
 
     // Hide download progress bar
     showDownloadPane(false);
@@ -52,7 +54,7 @@ MainWindow::MainWindow(QWidget *parent)
     connect(&models_, &QAbstractTableModel::rowsRemoved, this, &MainWindow::updateLocalModels);
     connect(&network_, &Network::error, this, &MainWindow::popupError); // All errors from the network class will be propagated to the GUI
     connect(&translatorSettingsDialog_, &TranslatorSettingsDialog::settingsChanged, this, &MainWindow::updateModelSettings);
-    
+
     // Queue translation when user has stopped typing for a bit
     connect(&inactivityTimer_, &QTimer::timeout, this, [&] {
         if (translateImmediately_)
@@ -224,6 +226,7 @@ void MainWindow::resetTranslator(QString dirname) {
     ui_->translateButton->setEnabled(true);
 
     // Set up the connection to the translator
+    connect(translator_.get(), &MarianInterface::pendingChanged, ui_->pendingIndicator, &QProgressBar::setVisible);
     connect(translator_.get(), &MarianInterface::translationReady, this, [&](QString translation) {
         ui_->outputBox->setText(translation);
         ui_->localModels->setEnabled(true); // Re-enable model changing

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -94,10 +94,10 @@ void MainWindow::on_inputBox_textChanged() {
     // Remove the last word, because it is likely incomplete
     auto lastSpace = inputText.lastIndexOf(" ");
     
-    while (lastSpace >= 0 && inputText[lastSpace].isSpace())
+    while (lastSpace > 0 && inputText[lastSpace-1].isSpace())
         --lastSpace;
 
-    if (lastSpace != -1)
+    if (lastSpace > 0)
         inputText.truncate(lastSpace);
 
     if (inputText != translationInput_) {

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -145,6 +145,31 @@
       </item>
      </layout>
     </item>
+    <item row="2" column="0">
+     <widget class="QProgressBar" name="pendingIndicator">
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <property name="maximumSize">
+       <size>
+        <width>100</width>
+        <height>16777215</height>
+       </size>
+      </property>
+      <property name="toolTip">
+       <string>Translating…</string>
+      </property>
+      <property name="maximum">
+       <number>0</number>
+      </property>
+      <property name="value">
+       <number>-1</number>
+      </property>
+     </widget>
+    </item>
    </layout>
   </widget>
   <widget class="QMenuBar" name="menubar">
@@ -153,7 +178,7 @@
      <x>0</x>
      <y>0</y>
      <width>493</width>
-     <height>44</height>
+     <height>24</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuEdit">
@@ -168,6 +193,7 @@
    </widget>
    <addaction name="menuEdit"/>
   </widget>
+  <widget class="QStatusBar" name="statusbar"/>
   <action name="translateAction">
    <property name="text">
     <string>Translate</string>


### PR DESCRIPTION
Implementation for #13. 

This adds a status bar with a little progress bar (of the infinite kind) in the right corner. The progress bar is visible if you can expect an updated translation to pop up. (It won't show if marian is still busy translating outdated input that will never make it to the screen.)

The progress bar is added to the window instead of the status bar in the UI file. On startup transplanted into the QProgressBar. QT Designer doesn't seem to have a way to directly add permanent widgets to a QStatusBar, unfortunately.

You should be able to also add things like words/second statistics to the status bar using `addWidget` with a `QLabel`.