### PR TITLE
Move interaction with marian into single thread

### DIFF
--- a/MarianInterface.h
+++ b/MarianInterface.h
@@ -2,8 +2,8 @@
 #define MARIANINTERFACE_H
 #include <QString>
 #include <QObject>
-#include <QAtomicInteger>
-#include <memory>
+#include <QAtomicPointer>
+#include <QSemaphore>
 #include "types.h"
 #include <thread>
 
@@ -17,9 +17,9 @@ namespace marian {
 class MarianInterface : public QObject {
     Q_OBJECT
 private:
-    std::unique_ptr<marian::bergamot::Service> service_;
-    QAtomicInteger<std::size_t> serial_;
-    QAtomicInteger<std::size_t> finished_;
+    QAtomicPointer<std::string> pendingInput_;
+    QSemaphore pendingInputCount_;
+    std::thread worker_;
 public:
     MarianInterface(QString path_to_model_dir, translateLocally::marianSettings& settings, QObject * parent);
     void translate(QString in);


### PR DESCRIPTION
Work-around for #11 which seems to be caused by multiple threads accessing the batcher concurrently. This also moves most of Marian's start up of the main thread.

There is some room for improvement before merging: the destructor waits for marian to finish. When switching models at start-up of translateLocally, this causes the GUI to hang for a few seconds. Ideally we could just detach the spinning down worker thread (or MarianInterface object) and have it clean up itself.

Re @XapaJIaMnu in #15: This change contains a "queue" of at most 1 pending text, which gets replaced with a newer input text if marian is still chewing on the previous input text. This way there's never more than three copies of input text floating around: one in the input text field, one in the input queue of MarianInterface, one in the worker (shared with Marian). (And one in the MainWindow used to determine whether the input changed enough to warrant sending it for translation again.)

