### PR TITLE
Move all marian interactions into worker

### DIFF
--- a/MarianInterface.cpp
+++ b/MarianInterface.cpp
@@ -6,11 +6,12 @@
 #include "3rd_party/bergamot-translator/3rd_party/marian-dev/src/3rd_party/spdlog/spdlog.h"
 #include <memory>
 #include <thread>
+#include <QMutexLocker>
 
 
 namespace  {
-marian::Ptr<marian::Options> MakeOptions(QString path_to_model_dir, translateLocally::marianSettings& settings) {
-    std::string model_path = path_to_model_dir.toStdString() + "config.intgemm8bitalpha.yml";
+marian::Ptr<marian::Options> MakeOptions(const std::string &path_to_model_dir, translateLocally::marianSettings& settings) {
+    std::string model_path = path_to_model_dir + "config.intgemm8bitalpha.yml";
     std::vector<std::string> args = {"marian-decoder", "-c", model_path,
                                      "--cpu-threads", std::to_string(settings.getCores()),
                                      "--workspace", std::to_string(settings.getWorkspace()),
@@ -26,61 +27,113 @@ marian::Ptr<marian::Options> MakeOptions(QString path_to_model_dir, translateLoc
     auto options = cp.parseOptions(argv.size(), &argv[0], true);
     return options;
 }
+
 } // Anonymous namespace
 
-MarianInterface::MarianInterface(QString path_to_model_dir, translateLocally::marianSettings& settings, QObject *parent)
-    : QObject(parent)
-    , pendingInput_()
-    , pendingInputCount_(0)
-    , mymodel(path_to_model_dir) {
+struct ModelDescription {
+    std::string config;
+    translateLocally::marianSettings settings;
+};
 
-    worker_ = std::thread([&](marian::Ptr<marian::Options> options) {
-        marian::bergamot::Service service(options);
+MarianInterface::MarianInterface(QObject *parent)
+    : QObject(parent)
+    , pendingInput_(nullptr)
+    , pendingModel_(nullptr) {
+    worker_ = std::thread([&]() {
+        std::unique_ptr<marian::bergamot::Service> service;
 
         while (true) {
+            std::unique_ptr<ModelDescription> model;
+            std::unique_ptr<std::string> input;
+
             // Wait for work
-            pendingInputCount_.acquire();
+            commandIssued_.acquire();
 
-            std::unique_ptr<std::string> input(pendingInput_.fetchAndStoreAcquire(nullptr));
-            // Empty ptr? pendingInputCount released without valid pointer -> poison (or a bug)
-            if (!input)
-                break;
+            {
+                // Lock while working with the pointers
+                QMutexLocker locker(&lock_);
 
+                // First check whether the command is loading a new model
+                if (pendingModel_)
+                    model = std::move(pendingModel_);
+                
+                // Second check whether command is translating something.
+                else if (pendingInput_)
+                    input = std::move(pendingInput_);
+                
+                // Command without any pending change -> poison.
+                else
+                    break;
+            }
+            
             emit pendingChanged(true);
+            
+            if (model) {
+                // Unload marian first (so we can delete loggers after that)
+                service.reset();
 
-            std::future<marian::bergamot::Response> responseFuture = service.translate(std::move(*input));
-            responseFuture.wait();
-            marian::bergamot::Response response = responseFuture.get();
-            emit translationReady(QString::fromStdString(response.target.text));
+                // We need to manually destroy the loggers, as marian doesn't do
+                // that but will complain when a new marian::Config tries to 
+                // initialise loggers with the same name.
+                spdlog::drop("general");
+                spdlog::drop("valid");
+
+                service.reset(new marian::bergamot::Service(MakeOptions(model->config, model->settings)));
+            } else if (input) {
+                std::future<marian::bergamot::Response> responseFuture = service->translate(std::move(*input));
+                responseFuture.wait();
+                marian::bergamot::Response response = responseFuture.get();
+                emit translationReady(QString::fromStdString(response.target.text));
+            }
 
             emit pendingChanged(false);
         }
+    });
+}
 
-        // We need to manually destroy the loggers, as marian doesn't do that.
-        spdlog::drop("general");
-        spdlog::drop("valid");
-    }, MakeOptions(path_to_model_dir, settings));
+QString const &MarianInterface::model() const {
+    return model_;
+}
+
+void MarianInterface::setModel(QString path_to_model_dir, translateLocally::marianSettings& settings) {
+    model_ = path_to_model_dir;
+    
+    // move my shared_ptr from stack to heap
+    QMutexLocker locker(&lock_);
+    std::unique_ptr<ModelDescription> model(new ModelDescription{model_.toStdString(), settings});
+    std::swap(pendingModel_, model);
+
+    // notify worker if there wasn't already a pending model
+    if (!model)
+        commandIssued_.release();
 }
 
 void MarianInterface::translate(QString in) {
-    std::unique_ptr<std::string> old(pendingInput_.fetchAndStoreAcquire(new std::string(in.toStdString())));
+    // If we don't have a model yet (loaded, or queued to be loaded, doesn't matter)
+    // then don't bother trying to translate something.
+    if (model_.isEmpty())
+        return;
 
-    // notify worker (but only if there wasn't already a pending task)
-    if (!old)
-        pendingInputCount_.release();
+    QMutexLocker locker(&lock_);
+    std::unique_ptr<std::string> input(new std::string(in.toStdString()));
+    std::swap(pendingInput_, input);
+    
+    if (!input)
+        commandIssued_.release();
 }
 
 MarianInterface::~MarianInterface() {
-    // Poision the worker with a nullptr
-    std::unique_ptr<std::string> old(pendingInput_.fetchAndStoreAcquire(nullptr));
-    if (!old)
-        pendingInputCount_.release();
+    // Remove all pending changes and unlock worker (which will then break.)
+    {
+        QMutexLocker locker(&lock_);
+        auto model = std::move(pendingModel_);
+        auto input = std::move(pendingInput_);
+
+        if (!input && !model)
+            commandIssued_.release();
+    }
     
     // Wait for worker to join as it depends on resources we still own.
-    // TODO: This might take a long time, can we just .detach() it instead somehow?
     worker_.join();
 }
 
-bool MarianInterface::pending() const {
-    return pendingInputCount_.available() != 0;
-}

--- a/MarianInterface.h
+++ b/MarianInterface.h
@@ -37,6 +37,7 @@ public:
 signals:
     void translationReady(QString translation);
     void pendingChanged(bool isBusy);
+    void error(QString message);
 };
 
 #endif // MARIANINTERFACE_H

--- a/main.cpp
+++ b/main.cpp
@@ -1,10 +1,14 @@
 #include "mainwindow.h"
+#include "3rd_party/bergamot-translator/3rd_party/marian-dev/src/marian.h"
 
 #include <QApplication>
 #include <QCommandLineParser>
 
 int main(int argc, char *argv[])
 {
+    // Set marian to throw exceptions instead of std::abort()
+    marian::setThrowExceptionOnAbort(true);
+
     QApplication translateLocally(argc, argv);
     QCoreApplication::setApplicationName("translateLocally");
     QCoreApplication::setApplicationVersion("0.02");

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -220,7 +220,8 @@ void MainWindow::translate(QString const &text) {
 
 void MainWindow::resetTranslator(QString dirname) {
     translator_->setModel(dirname + "/", models_.getSettings());
-    translate();
+    if (translateImmediately_)
+        translate();
 }
 
 /**

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -58,7 +58,6 @@ MainWindow::MainWindow(QWidget *parent)
     connect(translator_.get(), &MarianInterface::error, this, &MainWindow::popupError);
     connect(translator_.get(), &MarianInterface::translationReady, this, [&](QString translation) {
         ui_->outputBox->setText(translation);
-        ui_->localModels->setEnabled(true); // Re-enable model changing
         ui_->translateAction->setEnabled(true); // Re-enable button after translation is done
         ui_->translateButton->setEnabled(true);
     });

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -55,6 +55,7 @@ MainWindow::MainWindow(QWidget *parent)
 
     // Set up the connection to the translator
     connect(translator_.get(), &MarianInterface::pendingChanged, ui_->pendingIndicator, &QProgressBar::setVisible);
+    connect(translator_.get(), &MarianInterface::error, this, &MainWindow::popupError);
     connect(translator_.get(), &MarianInterface::translationReady, this, [&](QString translation) {
         ui_->outputBox->setText(translation);
         ui_->localModels->setEnabled(true); // Re-enable model changing

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -56,12 +56,7 @@ MainWindow::MainWindow(QWidget *parent)
     // Set up the connection to the translator
     connect(translator_.get(), &MarianInterface::pendingChanged, ui_->pendingIndicator, &QProgressBar::setVisible);
     connect(translator_.get(), &MarianInterface::error, this, &MainWindow::popupError);
-    connect(translator_.get(), &MarianInterface::translationReady, this, [&](QString translation) {
-        ui_->outputBox->setText(translation);
-        ui_->localModels->setEnabled(true); // Re-enable model changing
-        ui_->translateAction->setEnabled(true); // Re-enable button after translation is done
-        ui_->translateButton->setEnabled(true);
-    });
+    connect(translator_.get(), &MarianInterface::translationReady, ui_->outputBox, &QTextEdit::setText);
 
     // Queue translation when user has stopped typing for a bit
     connect(&inactivityTimer_, &QTimer::timeout, this, [&] {
@@ -205,8 +200,6 @@ void MainWindow::translate() {
 }
 
 void MainWindow::translate(QString const &text) {
-    ui_->translateAction->setEnabled(false); //Disable the translate button before the translation finishes
-    ui_->translateButton->setEnabled(false);
     if (translator_) {
         translator_->translate(text);
     } else {

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -56,7 +56,12 @@ MainWindow::MainWindow(QWidget *parent)
     // Set up the connection to the translator
     connect(translator_.get(), &MarianInterface::pendingChanged, ui_->pendingIndicator, &QProgressBar::setVisible);
     connect(translator_.get(), &MarianInterface::error, this, &MainWindow::popupError);
-    connect(translator_.get(), &MarianInterface::translationReady, ui_->outputBox, &QTextEdit::setText);
+    connect(translator_.get(), &MarianInterface::translationReady, this, [&](QString translation) {
+        ui_->outputBox->setText(translation);
+        ui_->localModels->setEnabled(true); // Re-enable model changing
+        ui_->translateAction->setEnabled(true); // Re-enable button after translation is done
+        ui_->translateButton->setEnabled(true);
+    });
 
     // Queue translation when user has stopped typing for a bit
     connect(&inactivityTimer_, &QTimer::timeout, this, [&] {
@@ -200,6 +205,8 @@ void MainWindow::translate() {
 }
 
 void MainWindow::translate(QString const &text) {
+    ui_->translateAction->setEnabled(false); //Disable the translate button before the translation finishes
+    ui_->translateButton->setEnabled(false);
     if (translator_) {
         translator_->translate(text);
     } else {


### PR DESCRIPTION
I've moved the (re)creation of `marian::bergamot::Service` into the worker itself, and added a `MarianInterface::setModel()` method.
- This removes the need to recreate the `MarianInterface` when switching models. (Yay no more `disconnect()` & `connect()`!)
- It organises the destruction of the old and construction of the new `marian::bergamot::Service` and `marian::Config` instances such there are never two at the same time. Because that causes trouble around the logging interface.
- Additionally, this moves the loading & destruction off the main thread keeping the interface "snappy".
- And I now throw & catch errors so loading a broken model no longer crashes the application.
- As a bonus, this change also fixes a possible race condition in my previous implementation.
- Finally I added some notes on why this design is as it is.
- Update: removed disabling translate button while translating as there is no technical reason to do so.