### PR TITLE
Persistent settings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,6 +106,8 @@ set(PROJECT_SOURCES
         ModelManager.h
         Network.cpp
         Network.h
+        Settings.cpp
+        Settings.h
         types.h
         ${TS_FILES}
 )

--- a/MarianInterface.cpp
+++ b/MarianInterface.cpp
@@ -11,7 +11,7 @@
 
 namespace  {
 marian::Ptr<marian::Options> MakeOptions(const std::string &path_to_model_dir, translateLocally::marianSettings& settings) {
-    std::string model_path = path_to_model_dir + "config.intgemm8bitalpha.yml";
+    std::string model_path = path_to_model_dir + "/config.intgemm8bitalpha.yml";
     std::vector<std::string> args = {"marian-decoder", "-c", model_path,
                                      "--cpu-threads", std::to_string(settings.cpu_threads),
                                      "--workspace", std::to_string(settings.workspace),
@@ -120,7 +120,7 @@ QString const &MarianInterface::model() const {
 
 void MarianInterface::setModel(QString path_to_model_dir, const translateLocally::marianSettings &settings) {
     model_ = path_to_model_dir;
-    
+
     // move my shared_ptr from stack to heap
     QMutexLocker locker(&lock_);
     std::unique_ptr<ModelDescription> model(new ModelDescription{model_.toStdString(), settings});

--- a/MarianInterface.cpp
+++ b/MarianInterface.cpp
@@ -13,8 +13,8 @@ namespace  {
 marian::Ptr<marian::Options> MakeOptions(const std::string &path_to_model_dir, translateLocally::marianSettings& settings) {
     std::string model_path = path_to_model_dir + "config.intgemm8bitalpha.yml";
     std::vector<std::string> args = {"marian-decoder", "-c", model_path,
-                                     "--cpu-threads", std::to_string(settings.getCores()),
-                                     "--workspace", std::to_string(settings.getWorkspace()),
+                                     "--cpu-threads", std::to_string(settings.cpu_threads),
+                                     "--workspace", std::to_string(settings.workspace),
                                      "--mini-batch-words", "1000"};
 
     std::vector<char *> argv;
@@ -118,7 +118,7 @@ QString const &MarianInterface::model() const {
     return model_;
 }
 
-void MarianInterface::setModel(QString path_to_model_dir, translateLocally::marianSettings& settings) {
+void MarianInterface::setModel(QString path_to_model_dir, const translateLocally::marianSettings &settings) {
     model_ = path_to_model_dir;
     
     // move my shared_ptr from stack to heap

--- a/MarianInterface.h
+++ b/MarianInterface.h
@@ -32,7 +32,7 @@ public:
     MarianInterface(QObject * parent);
     ~MarianInterface();
     QString const &model() const;
-    void setModel(QString path_to_model_dir, translateLocally::marianSettings& settings);
+    void setModel(QString path_to_model_dir, const translateLocally::marianSettings& settings);
     void translate(QString in);
 signals:
     void translationReady(QString translation);

--- a/ModelManager.h
+++ b/ModelManager.h
@@ -14,6 +14,10 @@ struct LocalModel {
     QString name;
     QString shortName;
     QString type;
+
+    inline operator bool() const {
+        return !path.isEmpty();
+    }
 };
 
 Q_DECLARE_METATYPE(LocalModel)
@@ -31,7 +35,7 @@ class ModelManager : public QAbstractTableModel {
 public:
     ModelManager(QObject *parent);
     void loadSettings();
-    void writeModel(QString filename, QByteArray data);
+    LocalModel writeModel(QString filename, QByteArray data);
 
     QList<LocalModel> installedModels() const;
     QList<RemoteModel> remoteModels() const;

--- a/Settings.cpp
+++ b/Settings.cpp
@@ -1,0 +1,23 @@
+#include "Settings.h"
+#include <thread>
+
+
+Settings::Settings(QObject *parent)
+: QObject(parent)
+, settings_(QSettings::NativeFormat, QSettings::UserScope, "translateLocally", "translateLocally")
+, cpu_cores_(settings_.value("cpu_cores", std::thread::hardware_concurrency()).toUInt())
+, workspace_(settings_.value("workspace", 128).toUInt()) {
+    connect(this, &Settings::coresChanged, this, [&](unsigned int cores) {
+        settings_.setValue("cpu_cores", cores);
+    });
+    connect(this, &Settings::workspaceChanged, this, [&](unsigned int workspace) {
+        settings_.setValue("workspace", workspace);
+    });
+}
+
+translateLocally::marianSettings Settings::marianSettings() const {
+    return {
+        cpu_cores_,
+        workspace_
+    };
+}

--- a/Settings.cpp
+++ b/Settings.cpp
@@ -1,7 +1,6 @@
 #include "Settings.h"
 #include <thread>
 
-
 Settings::Settings(QObject *parent)
 : QObject(parent)
 , settings_(QSettings::NativeFormat, QSettings::UserScope, "translateLocally", "translateLocally")
@@ -9,26 +8,15 @@ Settings::Settings(QObject *parent)
 , translation_model_(settings_.value("translation_model").toString())
 , cpu_cores_(settings_.value("cpu_cores", std::thread::hardware_concurrency()).toUInt())
 , workspace_(settings_.value("workspace", 128).toUInt()) {
-    connect(this, &Settings::translateImmediatelyChanged, this, [&](bool enable) {
-        settings_.setValue("translate_immediately", enable);
-    });
-
-    connect(this, &Settings::translationModelChanged, this, [&](QString path) {
-        settings_.setValue("translation_model", path);
-    });
-
-    connect(this, &Settings::coresChanged, this, [&](unsigned int cores) {
-        settings_.setValue("cpu_cores", cores);
-    });
-    
-    connect(this, &Settings::workspaceChanged, this, [&](unsigned int workspace) {
-        settings_.setValue("workspace", workspace);
-    });
+    bind("translate_immediately", &Settings::translateImmediatelyChanged);
+    bind("translation_model", &Settings::translationModelChanged);
+    bind("cpu_cores", &Settings::coresChanged);
+    bind("workspace", &Settings::workspaceChanged);
 }
 
 translateLocally::marianSettings Settings::marianSettings() const {
     return {
-        cpu_cores_,
-        workspace_
+        cores(),
+        workspace()
     };
 }

--- a/Settings.cpp
+++ b/Settings.cpp
@@ -5,9 +5,14 @@
 Settings::Settings(QObject *parent)
 : QObject(parent)
 , settings_(QSettings::NativeFormat, QSettings::UserScope, "translateLocally", "translateLocally")
+, translate_immediately_(settings_.value("translate_immediately", true).toBool())
 , translation_model_(settings_.value("translation_model").toString())
 , cpu_cores_(settings_.value("cpu_cores", std::thread::hardware_concurrency()).toUInt())
 , workspace_(settings_.value("workspace", 128).toUInt()) {
+    connect(this, &Settings::translateImmediatelyChanged, this, [&](bool enable) {
+        settings_.setValue("translate_immediately", enable);
+    });
+
     connect(this, &Settings::translationModelChanged, this, [&](QString path) {
         settings_.setValue("translation_model", path);
     });

--- a/Settings.cpp
+++ b/Settings.cpp
@@ -5,11 +5,17 @@
 Settings::Settings(QObject *parent)
 : QObject(parent)
 , settings_(QSettings::NativeFormat, QSettings::UserScope, "translateLocally", "translateLocally")
+, translation_model_(settings_.value("translation_model").toString())
 , cpu_cores_(settings_.value("cpu_cores", std::thread::hardware_concurrency()).toUInt())
 , workspace_(settings_.value("workspace", 128).toUInt()) {
+    connect(this, &Settings::translationModelChanged, this, [&](QString path) {
+        settings_.setValue("translation_model", path);
+    });
+
     connect(this, &Settings::coresChanged, this, [&](unsigned int cores) {
         settings_.setValue("cpu_cores", cores);
     });
+    
     connect(this, &Settings::workspaceChanged, this, [&](unsigned int workspace) {
         settings_.setValue("workspace", workspace);
     });

--- a/Settings.cpp
+++ b/Settings.cpp
@@ -1,22 +1,23 @@
 #include "Settings.h"
 #include <thread>
 
+void Setting::emitValueChanged(QString name, QVariant value) {
+    emit valueChanged(name, value);
+}
+
 Settings::Settings(QObject *parent)
 : QObject(parent)
-, settings_(QSettings::NativeFormat, QSettings::UserScope, "translateLocally", "translateLocally")
-, translate_immediately_(settings_.value("translate_immediately", true).toBool())
-, translation_model_(settings_.value("translation_model").toString())
-, cpu_cores_(settings_.value("cpu_cores", std::thread::hardware_concurrency()).toUInt())
-, workspace_(settings_.value("workspace", 128).toUInt()) {
-    bind("translate_immediately", &Settings::translateImmediatelyChanged);
-    bind("translation_model", &Settings::translationModelChanged);
-    bind("cpu_cores", &Settings::coresChanged);
-    bind("workspace", &Settings::workspaceChanged);
+, backing_(QSettings::NativeFormat, QSettings::UserScope, "translateLocally", "translateLocally")
+, translateImmediately(backing_, "translate_immediately", true)
+, translationModel(backing_, "translation_model", "")
+, cores(backing_, "cpu_cores", std::thread::hardware_concurrency())
+, workspace(backing_, "workspace", 128) {
+    //
 }
 
 translateLocally::marianSettings Settings::marianSettings() const {
     return {
-        cores(),
-        workspace()
+        cores.value(),
+        workspace.value()
     };
 }

--- a/Settings.cpp
+++ b/Settings.cpp
@@ -11,7 +11,9 @@ Settings::Settings(QObject *parent)
 , translateImmediately(backing_, "translate_immediately", true)
 , translationModel(backing_, "translation_model", "")
 , cores(backing_, "cpu_cores", std::thread::hardware_concurrency())
-, workspace(backing_, "workspace", 128) {
+, workspace(backing_, "workspace", 128)
+, inputText(backing_, "input_text", "") 
+, inputPosition(backing_, "input_position", 0) {
     //
 }
 

--- a/Settings.h
+++ b/Settings.h
@@ -7,16 +7,27 @@
 class Settings : public QObject 
 {
     Q_OBJECT
-    Q_PROPERTY(unsigned int cores MEMBER cpu_cores_ NOTIFY coresChanged)
-    Q_PROPERTY(unsigned int workspace MEMBER workspace_ NOTIFY workspaceChanged)
+    Q_PROPERTY(QString translationModel READ translationModel WRITE setTranslationModel NOTIFY translationModelChanged)
+    Q_PROPERTY(unsigned int cores READ cores WRITE setCores NOTIFY coresChanged)
+    Q_PROPERTY(unsigned int workspace READ workspace WRITE setWorkspace NOTIFY workspaceChanged)
 
 private:
     QSettings settings_;
+    QString translation_model_;
     unsigned int cpu_cores_;
     unsigned int workspace_;
 public:
     Settings(QObject *parent = nullptr);
     translateLocally::marianSettings marianSettings() const;
+
+    inline void setTranslationModel(QString path) {
+        translation_model_ = path;
+        emit translationModelChanged(path);
+    }
+
+    inline QString translationModel() const {
+        return translation_model_;
+    }
 
     inline void setCores(unsigned int cores) {
         cpu_cores_ = cores;
@@ -37,6 +48,7 @@ public:
     }
 
 signals:
+    void translationModelChanged(QString path);
     void coresChanged(unsigned int cores);
     void workspaceChanged(unsigned int workspace);
 };

--- a/Settings.h
+++ b/Settings.h
@@ -3,10 +3,10 @@
 #include <QSettings>
 #include "types.h"
 
-
 class Settings : public QObject 
 {
     Q_OBJECT
+    Q_PROPERTY(bool translateImmediately READ translateImmediately WRITE setTranslateImmediately NOTIFY translateImmediatelyChanged)
     Q_PROPERTY(QString translationModel READ translationModel WRITE setTranslationModel NOTIFY translationModelChanged)
     Q_PROPERTY(unsigned int cores READ cores WRITE setCores NOTIFY coresChanged)
     Q_PROPERTY(unsigned int workspace READ workspace WRITE setWorkspace NOTIFY workspaceChanged)
@@ -55,6 +55,14 @@ public:
 
     inline unsigned int workspace() const {
         return workspace_;
+    }
+
+private:
+    template <typename T>
+    void bind(QString name, void (Settings::*signal)(T)) {
+        connect(this, signal, this, [&, name] (T value) {
+            settings_.setValue(name, value);
+        });
     }
 
 signals:

--- a/Settings.h
+++ b/Settings.h
@@ -13,12 +13,22 @@ class Settings : public QObject
 
 private:
     QSettings settings_;
+    bool translate_immediately_;
     QString translation_model_;
     unsigned int cpu_cores_;
     unsigned int workspace_;
 public:
     Settings(QObject *parent = nullptr);
     translateLocally::marianSettings marianSettings() const;
+
+    inline void setTranslateImmediately(bool enable) {
+        translate_immediately_ = enable;
+        emit translateImmediatelyChanged(enable);
+    }
+
+    inline bool translateImmediately() const {
+        return translate_immediately_;
+    }
 
     inline void setTranslationModel(QString path) {
         translation_model_ = path;
@@ -48,6 +58,7 @@ public:
     }
 
 signals:
+    void translateImmediatelyChanged(bool);
     void translationModelChanged(QString path);
     void coresChanged(unsigned int cores);
     void workspaceChanged(unsigned int workspace);

--- a/Settings.h
+++ b/Settings.h
@@ -3,71 +3,82 @@
 #include <QSettings>
 #include "types.h"
 
-class Settings : public QObject 
-{
+/**
+ * Settings:
+ * Class that houses all the invidividual settings. Also responsible
+ * for providing the QSettings instance used by individidual settings.
+ */
+class Settings;
+
+
+/**
+ * Setting:
+ * Type-independent base class for each setting. Separate from the
+ * templated Setting<T> class because Q_OBJECT + templates does not work.
+ * This class is the interface referenced elsewhere when connecting to the
+ * `valueChanged` signal.
+ */
+class Setting : public QObject {
     Q_OBJECT
-    Q_PROPERTY(bool translateImmediately READ translateImmediately WRITE setTranslateImmediately NOTIFY translateImmediatelyChanged)
-    Q_PROPERTY(QString translationModel READ translationModel WRITE setTranslationModel NOTIFY translationModelChanged)
-    Q_PROPERTY(unsigned int cores READ cores WRITE setCores NOTIFY coresChanged)
-    Q_PROPERTY(unsigned int workspace READ workspace WRITE setWorkspace NOTIFY workspaceChanged)
 
-private:
-    QSettings settings_;
-    bool translate_immediately_;
-    QString translation_model_;
-    unsigned int cpu_cores_;
-    unsigned int workspace_;
-public:
-    Settings(QObject *parent = nullptr);
-    translateLocally::marianSettings marianSettings() const;
-
-    inline void setTranslateImmediately(bool enable) {
-        translate_immediately_ = enable;
-        emit translateImmediatelyChanged(enable);
-    }
-
-    inline bool translateImmediately() const {
-        return translate_immediately_;
-    }
-
-    inline void setTranslationModel(QString path) {
-        translation_model_ = path;
-        emit translationModelChanged(path);
-    }
-
-    inline QString translationModel() const {
-        return translation_model_;
-    }
-
-    inline void setCores(unsigned int cores) {
-        cpu_cores_ = cores;
-        emit coresChanged(cores);
-    }
-
-    inline unsigned int cores() const {
-        return cpu_cores_;
-    }
-
-    inline void setWorkspace(unsigned int workspace) {
-        workspace_ = workspace;
-        emit workspaceChanged(workspace);
-    }
-
-    inline unsigned int workspace() const {
-        return workspace_;
-    }
-
-private:
-    template <typename T>
-    void bind(QString name, void (Settings::*signal)(T)) {
-        connect(this, signal, this, [&, name] (T value) {
-            settings_.setValue(name, value);
-        });
-    }
+protected:
+    void emitValueChanged(QString name, QVariant value);
 
 signals:
-    void translateImmediatelyChanged(bool);
-    void translationModelChanged(QString path);
-    void coresChanged(unsigned int cores);
-    void workspaceChanged(unsigned int workspace);
+    void valueChanged(QString name, QVariant value);
+};
+
+
+/**
+ * SettingImpl<T>:
+ * Class that represents an individual setting. Similar to QProperty in Qt6.
+ */
+template <typename T>
+class SettingImpl : public Setting {
+private:
+    QString name_;
+    T value_;
+
+public:
+    SettingImpl(QSettings &backing, QString name, T defaultValue = T())
+    : name_(name)
+    , value_(backing.value(name, defaultValue).template value<T>()) {
+        // When the value changes, also store it in QSettings
+        connect(this, &Setting::valueChanged, &backing, &QSettings::setValue);
+    }
+
+    T value() const {
+        return value_;
+    }
+
+    void setValue(T value) {
+        // Don't emit when the value doesn't change
+        if (value == value_)
+            return;
+
+        value_ = value;
+        emitValueChanged(name_, value_);
+    }
+
+    // Alias for value() to make Settings make look more like a normal Qt class.
+    T operator()() const {
+        return value();
+    }
+};
+
+
+class Settings : public QObject  {
+    Q_OBJECT
+private:
+    QSettings backing_;
+
+public:
+    Settings(QObject *parent = nullptr);
+    // For easy passing through of marian-related settings
+    translateLocally::marianSettings marianSettings() const;
+
+    SettingImpl<bool> translateImmediately;
+    SettingImpl<QString> translationModel;
+    SettingImpl<unsigned int> cores;
+    SettingImpl<unsigned int> workspace;
 };

--- a/Settings.h
+++ b/Settings.h
@@ -81,4 +81,6 @@ public:
     SettingImpl<QString> translationModel;
     SettingImpl<unsigned int> cores;
     SettingImpl<unsigned int> workspace;
+    SettingImpl<QString> inputText;
+    SettingImpl<int> inputPosition;
 };

--- a/Settings.h
+++ b/Settings.h
@@ -1,0 +1,42 @@
+#pragma once
+#include <QObject>
+#include <QSettings>
+#include "types.h"
+
+
+class Settings : public QObject 
+{
+    Q_OBJECT
+    Q_PROPERTY(unsigned int cores MEMBER cpu_cores_ NOTIFY coresChanged)
+    Q_PROPERTY(unsigned int workspace MEMBER workspace_ NOTIFY workspaceChanged)
+
+private:
+    QSettings settings_;
+    unsigned int cpu_cores_;
+    unsigned int workspace_;
+public:
+    Settings(QObject *parent = nullptr);
+    translateLocally::marianSettings marianSettings() const;
+
+    inline void setCores(unsigned int cores) {
+        cpu_cores_ = cores;
+        emit coresChanged(cores);
+    }
+
+    inline unsigned int cores() const {
+        return cpu_cores_;
+    }
+
+    inline void setWorkspace(unsigned int workspace) {
+        workspace_ = workspace;
+        emit workspaceChanged(workspace);
+    }
+
+    inline unsigned int workspace() const {
+        return workspace_;
+    }
+
+signals:
+    void coresChanged(unsigned int cores);
+    void workspaceChanged(unsigned int workspace);
+};

--- a/TranslatorSettingsDialog.cpp
+++ b/TranslatorSettingsDialog.cpp
@@ -38,6 +38,6 @@ TranslatorSettingsDialog::~TranslatorSettingsDialog()
 
 void TranslatorSettingsDialog::on_buttonBox_accepted()
 {
-    settings_->setCores(ui_->coresBox->currentData().toUInt());
-    settings_->setWorkspace(ui_->memoryBox->currentData().toUInt());
+    settings_->cores.setValue(ui_->coresBox->currentData().toUInt());
+    settings_->workspace.setValue(ui_->memoryBox->currentData().toUInt());
 }

--- a/TranslatorSettingsDialog.h
+++ b/TranslatorSettingsDialog.h
@@ -2,7 +2,7 @@
 #define TRANSLATORSETTINGS_H
 
 #include <QDialog>
-#include "types.h"
+#include "Settings.h"
 
 namespace Ui {
 class TranslatorSettingsDialog;
@@ -13,22 +13,15 @@ class TranslatorSettingsDialog : public QDialog
     Q_OBJECT
 
 public:
-    explicit TranslatorSettingsDialog(QWidget *parent, translateLocally::marianSettings& settings);
+    explicit TranslatorSettingsDialog(QWidget *parent, Settings *settings);
     ~TranslatorSettingsDialog();
 
 private slots:
     void on_buttonBox_accepted();
 
-signals:
-    void settingsChanged(size_t memory, size_t cores);
-
 private:
-    Ui::TranslatorSettingsDialog *ui;
-    const translateLocally::marianSettings& settings_;
-    QList<size_t> cores_;
-    QStringList coresStr_;
-    QList<size_t> memory_;
-    QStringList memoryStr_;
+    Ui::TranslatorSettingsDialog *ui_;
+    Settings *settings_;
 };
 
 #endif // TRANSLATORSETTINGS_H

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -241,7 +241,7 @@ void MainWindow::translate(QString const &text) {
  */
 
 void MainWindow::resetTranslator(QString dirname) {
-    translator_->setModel(dirname + "/", settings_.marianSettings());
+    translator_->setModel(settings_.translationModel(), settings_.marianSettings());
     if (translateImmediately_)
         translate();
 }

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -42,7 +42,7 @@ MainWindow::MainWindow(QWidget *parent)
 
     // If no model is preferred, load the first available one.
     if (settings_.translationModel().isEmpty() && !models_.installedModels().empty())
-        settings_.setTranslationModel(models_.installedModels().first().path);
+        settings_.translationModel.setValue(models_.installedModels().first().path);
 
     inactivityTimer_.setInterval(300);
     inactivityTimer_.setSingleShot(true);
@@ -76,16 +76,16 @@ MainWindow::MainWindow(QWidget *parent)
     });
 
     // Connect translate immediately toggle in both directions
-    connect(ui_->actionTranslateImmediately, &QAction::toggled, &settings_, &Settings::setTranslateImmediately);
-    connect(&settings_, &Settings::translateImmediatelyChanged, this, &MainWindow::updateTranslateImmediately);
+    connect(ui_->actionTranslateImmediately, &QAction::toggled, &settings_.translateImmediately, &decltype(Settings::translateImmediately)::setValue);
+    connect(&settings_.translateImmediately, &Setting::valueChanged, this, &MainWindow::updateTranslateImmediately);
 
     // Update selected model when model changes
-    connect(&settings_, &Settings::translationModelChanged, this, &MainWindow::updateSelectedModel);
+    connect(&settings_.translationModel, &Setting::valueChanged, this, &MainWindow::updateSelectedModel);
 
     // Connect settings changes to reloading the model.
-    connect(&settings_, &Settings::coresChanged, this, &MainWindow::resetTranslator);
-    connect(&settings_, &Settings::workspaceChanged, this, &MainWindow::resetTranslator);
-    connect(&settings_, &Settings::translationModelChanged, this, &MainWindow::resetTranslator);
+    connect(&settings_.cores, &Setting::valueChanged, this, &MainWindow::resetTranslator);
+    connect(&settings_.workspace, &Setting::valueChanged, this, &MainWindow::resetTranslator);
+    connect(&settings_.translationModel, &Setting::valueChanged, this, &MainWindow::resetTranslator);
 
     // Initial state sync between settings & UI
     // TODO: Does Qt5 not have some form of bi-directional data binding? Looks
@@ -147,7 +147,7 @@ void MainWindow::showDownloadPane(bool visible)
 void MainWindow::handleDownload(QString filename, QByteArray data) {
     LocalModel model = models_.writeModel(filename, data);
     if (model)
-        settings_.setTranslationModel(model.path);
+        settings_.translationModel.setValue(model.path);
 }
 
 void MainWindow::downloadProgress(qint64 ist, qint64 max) {
@@ -181,7 +181,7 @@ void MainWindow::on_localModels_activated(int index) {
     QVariant data = ui_->localModels->itemData(index);
 
     if (data.canConvert<LocalModel>()) {
-        settings_.setTranslationModel(data.value<LocalModel>().path);
+        settings_.translationModel.setValue(data.value<LocalModel>().path);
     } else if (data.canConvert<RemoteModel>()) {
         downloadModel(data.value<RemoteModel>());
     } else if (data == Action::FetchRemoteModels) {

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -145,7 +145,9 @@ void MainWindow::showDownloadPane(bool visible)
 }
 
 void MainWindow::handleDownload(QString filename, QByteArray data) {
-    models_.writeModel(filename, data);
+    LocalModel model = models_.writeModel(filename, data);
+    if (model)
+        settings_.setTranslationModel(model.path);
 }
 
 void MainWindow::downloadProgress(qint64 ist, qint64 max) {
@@ -164,6 +166,8 @@ void MainWindow::downloadModel(RemoteModel model) {
     QNetworkReply *reply = network_.downloadFile(model.url);
     connect(ui_->cancelDownloadButton, &QPushButton::clicked, reply, &QNetworkReply::abort, Qt::UniqueConnection);
     connect(reply, &QNetworkReply::finished, this, [&]() {
+        // Hide it here instead of in handleDownload() because finished() also
+        // triggers on abort.
         showDownloadPane(false);
     });
 }

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -75,17 +75,8 @@ MainWindow::MainWindow(QWidget *parent)
     });
 
     // Update selected model when model changes
-    connect(&settings_, &Settings::translationModelChanged, this, [&] (QString path) {
-        for (int i = 0; i < ui_->localModels->count(); ++i) {
-            QVariant item = ui_->localModels->itemData(i);
-            if (item.canConvert<LocalModel>() && item.value<LocalModel>().path == path) {
-                ui_->localModels->setCurrentIndex(i);
-                break;
-            }
-        }
+    connect(&settings_, &Settings::translationModelChanged, this, &MainWindow::updateSelectedModel);
 
-        qDebug() << "Could not find" << path << "among" << ui_->localModels->count() << "items";
-    });
 
     // TODO: figure out if I can bind variables (Qt6 can, but 5?) so it resets
     // the translator once on load, and then every time it changes.
@@ -199,6 +190,7 @@ void MainWindow::on_localModels_activated(int index) {
 void MainWindow::updateLocalModels() {
     // Clear out current items
     ui_->localModels->clear();
+    ui_->localModels->setCurrentIndex(-1);
 
     // Add local models
     if (!models_.installedModels().empty()) {
@@ -217,6 +209,19 @@ void MainWindow::updateLocalModels() {
         for (auto &&model : models_.availableModels())
             ui_->localModels->addItem(model.name, QVariant::fromValue(model));
     }
+}
+
+void MainWindow::updateSelectedModel() {
+    for (int i = 0; i < ui_->localModels->count(); ++i) {
+        QVariant item = ui_->localModels->itemData(i);
+        if (item.canConvert<LocalModel>() && item.value<LocalModel>().path == settings_.translationModel()) {
+            ui_->localModels->setCurrentIndex(i);
+            return;
+        }
+    }
+
+    // Model not found? Don't select any option at all.
+    ui_->localModels->setCurrentIndex(-1);
 }
 
 

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -94,9 +94,19 @@ MainWindow::MainWindow(QWidget *parent)
     resetTranslator();
     updateSelectedModel();
     updateTranslateImmediately();
+
+    // Restore input text and caret position
+    ui_->inputBox->setPlainText(settings_.inputText());
+    QTextCursor cursor = ui_->inputBox->textCursor();
+    cursor.setPosition(settings_.inputPosition());
+    ui_->inputBox->setTextCursor(cursor);
 }
 
 MainWindow::~MainWindow() {
+    // Safe input text on exit
+    settings_.inputText.setValue(ui_->inputBox->toPlainText());
+    settings_.inputPosition.setValue(ui_->inputBox->textCursor().position());
+
     delete ui_;
 }
 

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -60,6 +60,7 @@ private slots:
 
     void updateLocalModels();
 
+    void updateSelectedModel();
 
 private:
     Ui::MainWindow * ui_; // Sadly QTCreator can't do its job if Ui::MainWindow is wrapped inside a smart ptr, so raw pointer it is

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -60,13 +60,12 @@ private slots:
 
     void updateLocalModels();
 
-    void reloadTranslator(unsigned int);
 
 private:
     Ui::MainWindow * ui_; // Sadly QTCreator can't do its job if Ui::MainWindow is wrapped inside a smart ptr, so raw pointer it is
     // Translator related settings
     std::unique_ptr<MarianInterface> translator_;
-    void resetTranslator(QString dirname);
+    void resetTranslator();
     void showDownloadPane(bool visible);
     void downloadModel(RemoteModel model);
 

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -8,7 +8,7 @@
 #include "ModelManager.h"
 #include "ModelListItemDelegate.h"
 #include "TranslatorSettingsDialog.h"
-#include "types.h"
+#include "Settings.h"
 
 class MarianInterface;
 
@@ -60,6 +60,8 @@ private slots:
 
     void updateLocalModels();
 
+    void reloadTranslator(unsigned int);
+
 private:
     Ui::MainWindow * ui_; // Sadly QTCreator can't do its job if Ui::MainWindow is wrapped inside a smart ptr, so raw pointer it is
     // Translator related settings
@@ -74,6 +76,7 @@ private:
     QStringList names_;
 
     // Model and config manager
+    Settings settings_;
     ModelManager models_;
     ModelListItemDelegate localModelDelegate_;
     TranslatorSettingsDialog translatorSettingsDialog_;

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -35,7 +35,7 @@ public:
     Q_ENUM(Action);
 
 public slots:
-    void setTranslateImmediately(bool);
+    
 
 private slots:
     void on_inputBox_textChanged();
@@ -50,8 +50,6 @@ private slots:
 
     void on_localModels_activated(int index);
 
-    void on_actionTranslateImmediately_toggled(bool);
-
     void popupError(QString error);
 
     void translate();
@@ -61,6 +59,8 @@ private slots:
     void updateLocalModels();
 
     void updateSelectedModel();
+
+    void updateTranslateImmediately();
 
 private:
     Ui::MainWindow * ui_; // Sadly QTCreator can't do its job if Ui::MainWindow is wrapped inside a smart ptr, so raw pointer it is
@@ -86,7 +86,5 @@ private:
 
     QTimer inactivityTimer_;
     QString translationInput_;
-
-    bool translateImmediately_;
 };
 #endif // MAINWINDOW_H

--- a/types.h
+++ b/types.h
@@ -1,27 +1,10 @@
 #pragma once
-#include <thread>
+
 namespace translateLocally {
 
-    class marianSettings {
-    private:
-        size_t cpu_cores_;
-        size_t workspace_;
-    public:
-        marianSettings() : cpu_cores_(std::thread::hardware_concurrency()), workspace_(128) {}
-        marianSettings(size_t cores, size_t memory) : cpu_cores_(cores), workspace_(memory) {}
-        void setCores(size_t cores) {
-            cpu_cores_ = cores;
-        }
-        void setWorkspace(size_t memory) {
-            workspace_ = memory;
-        }
-
-        size_t getCores() const {
-            return cpu_cores_;
-        }
-        size_t getWorkspace() const {
-            return workspace_;
-        }
-    };
+struct marianSettings {
+    size_t cpu_threads;
+    size_t workspace;
+};
 
 } // namespace translateLocally


### PR DESCRIPTION
Implementation for #23 (and accidentally also #18…)

This adds a class `Settings` that describes the state of the application.
1. Each setting is described by a `Setting` class which signals changes. Other parts of the application can listen to these changes to update UI and translation model.  
Technically this is split up in `Setting(extends QObject)` and `SettingImpl<T>(extends Setting)`. This because you can't use Q_OBJECT (and thus signals) with template classes, but I did want to use templates to describe the data type of settings.
2. Most settings are saved & applied when they change (synced through signals). Exception is the inputText (and cursor position) as these change quite often, but have little impact across the application. Therefore these are only loaded & saved on application startup & shutdown.
3. It stores both input text and cursor position (to give the impression you can just pick up where you left off last time). ~~I do not trigger translation on restoring the input text when `translateImmediately` is enabled to prevent accidental lengthy translation processes. Once cancelling a translation is implemented, this should probably change.~~ `translateImmediately? translate()` will trigger on load as well because restoring the text emits the `inputBox_textChanged` signal.
4. I changed `ModelManager::writeModel` to return the model so it can be automatically selected when it finishes downloading & extracting. 
5. Changed the dropdown option generation in the settings dialog a bit to use the userData field of the options. Makes the code a bit more copy/pastable (or easier to move around).