### PR TITLE
Horizontal split option

### DIFF
--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -11,7 +11,8 @@ Settings::Settings(QObject *parent)
 , translateImmediately(backing_, "translate_immediately", true)
 , translationModel(backing_, "translation_model", "")
 , cores(backing_, "cpu_cores", std::thread::hardware_concurrency())
-, workspace(backing_, "workspace", 128) {
+, workspace(backing_, "workspace", 128)
+, splitOrientation(backing_, "split", Qt::Vertical) {
     //
 }
 

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -12,7 +12,8 @@ Settings::Settings(QObject *parent)
 , translationModel(backing_, "translation_model", "")
 , cores(backing_, "cpu_cores", std::thread::hardware_concurrency())
 , workspace(backing_, "workspace", 128)
-, splitOrientation(backing_, "split", Qt::Vertical) {
+, splitOrientation(backing_, "split", Qt::Vertical)
+, windowGeometry(backing_, "window_geometry") {
     //
 }
 

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -82,4 +82,5 @@ public:
     SettingImpl<unsigned int> cores;
     SettingImpl<unsigned int> workspace;
     SettingImpl<Qt::Orientation> splitOrientation;
+    SettingImpl<QByteArray> windowGeometry;
 };

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -81,4 +81,5 @@ public:
     SettingImpl<QString> translationModel;
     SettingImpl<unsigned int> cores;
     SettingImpl<unsigned int> workspace;
+    SettingImpl<Qt::Orientation> splitOrientation;
 };

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -91,6 +91,13 @@ MainWindow::MainWindow(QWidget *parent)
         ui_->translateButton->setVisible(!enabled);
     });
 
+    // Connect changing split orientation
+    bind(settings_.splitOrientation, [&](Qt::Orientation orientation) {
+        ui_->splitter->setOrientation(orientation);
+        ui_->actionSplit_Horizontally->setChecked(orientation == Qt::Horizontal);
+        ui_->actionSplit_Vertically->setChecked(orientation == Qt::Vertical);
+    });
+
     // Update selected model when model changes
     bind(settings_.translationModel, [&](QString path) {
         Q_UNUSED(path);
@@ -293,11 +300,18 @@ void MainWindow::popupError(QString error) {
     msgBox.exec();
 }
 
-void MainWindow::on_fontAction_triggered()
-{
+void MainWindow::on_fontAction_triggered() {
     this->setFont(QFontDialog::getFont(0, this->font()));
 }
 
 void MainWindow::on_actionTranslator_Settings_triggered() {
     this->translatorSettingsDialog_.setVisible(true);
+}
+
+void MainWindow::on_actionSplit_Horizontally_triggered() {
+    settings_.splitOrientation.setValue(Qt::Horizontal);
+}
+
+void MainWindow::on_actionSplit_Vertically_triggered() {
+    settings_.splitOrientation.setValue(Qt::Vertical);
 }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -98,6 +98,9 @@ MainWindow::MainWindow(QWidget *parent)
         ui_->actionSplit_Vertically->setChecked(orientation == Qt::Vertical);
     });
 
+    // Restore window size
+    restoreGeometry(settings_.windowGeometry());
+
     // Update selected model when model changes
     bind(settings_.translationModel, [&](QString path) {
         Q_UNUSED(path);
@@ -117,6 +120,7 @@ MainWindow::MainWindow(QWidget *parent)
 }
 
 MainWindow::~MainWindow() {
+    settings_.windowGeometry.setValue(saveGeometry());
     delete ui_;
 }
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -86,10 +86,16 @@ MainWindow::MainWindow(QWidget *parent)
 
     // Connect translate immediately toggle in both directions
     connect(ui_->actionTranslateImmediately, &QAction::toggled, &settings_.translateImmediately, &decltype(Settings::translateImmediately)::setValue);
-    connect(&settings_.translateImmediately, &Setting::valueChanged, this, &MainWindow::updateTranslateImmediately);
+    bind(settings_.translateImmediately, [&](bool enabled) {
+        ui_->actionTranslateImmediately->setChecked(enabled);
+        ui_->translateButton->setVisible(!enabled);
+    });
 
     // Update selected model when model changes
-    connect(&settings_.translationModel, &Setting::valueChanged, this, &MainWindow::updateSelectedModel);
+    bind(settings_.translationModel, [&](QString path) {
+        Q_UNUSED(path);
+        updateSelectedModel();
+    });
 
     // Connect settings changes to reloading the model.
     connect(&settings_.cores, &Setting::valueChanged, this, &MainWindow::resetTranslator);
@@ -101,17 +107,10 @@ MainWindow::MainWindow(QWidget *parent)
     // like it's only available in QtQuick and starting Qt6 in C++.
     // Note: both are safe when no model is set.
     resetTranslator();
-    updateSelectedModel();
-    updateTranslateImmediately();
 }
 
 MainWindow::~MainWindow() {
     delete ui_;
-}
-
-void MainWindow::updateTranslateImmediately() {
-    ui_->actionTranslateImmediately->setChecked(settings_.translateImmediately());
-    ui_->translateButton->setVisible(!settings_.translateImmediately());
 }
 
 void MainWindow::on_translateAction_triggered() {

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -50,6 +50,10 @@ private slots:
 
     void on_localModels_activated(int index);
 
+    void on_actionSplit_Horizontally_triggered();
+
+    void on_actionSplit_Vertically_triggered();
+
     void popupError(QString error);
 
     void translate();

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -60,8 +60,6 @@ private slots:
 
     void updateSelectedModel();
 
-    void updateTranslateImmediately();
-
 private:
     Ui::MainWindow * ui_; // Sadly QTCreator can't do its job if Ui::MainWindow is wrapped inside a smart ptr, so raw pointer it is
     // Translator related settings
@@ -86,5 +84,16 @@ private:
 
     QTimer inactivityTimer_;
     QString translationInput_;
+
+    template <typename T, typename Fun>
+    void bind(SettingImpl<T> &setting, Fun update) {
+        // Update initially
+        update(setting.value());
+
+        // Update every time it changes
+        connect(&setting, &Setting::valueChanged, [&, update]{
+            update(setting.value());
+        });
+    }
 };
 #endif // MAINWINDOW_H

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -38,6 +38,12 @@
        </property>
        <item>
         <widget class="QSplitter" name="splitter">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
          <property name="orientation">
           <enum>Qt::Vertical</enum>
          </property>
@@ -191,7 +197,15 @@
     <addaction name="separator"/>
     <addaction name="fontAction"/>
    </widget>
+   <widget class="QMenu" name="menuView">
+    <property name="title">
+     <string>View</string>
+    </property>
+    <addaction name="actionSplit_Horizontally"/>
+    <addaction name="actionSplit_Vertically"/>
+   </widget>
    <addaction name="menuEdit"/>
+   <addaction name="menuView"/>
   </widget>
   <widget class="QStatusBar" name="statusbar"/>
   <action name="translateAction">
@@ -221,6 +235,22 @@
    </property>
    <property name="text">
     <string>Translate as I type</string>
+   </property>
+  </action>
+  <action name="actionSplit_Horizontally">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Split Horizontally</string>
+   </property>
+  </action>
+  <action name="actionSplit_Vertically">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Split Vertically</string>
    </property>
   </action>
  </widget>

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -244,6 +244,9 @@
    <property name="text">
     <string>Split Horizontally</string>
    </property>
+   <property name="shortcut">
+    <string>Ctrl+1</string>
+   </property>
   </action>
   <action name="actionSplit_Vertically">
    <property name="checkable">
@@ -251,6 +254,9 @@
    </property>
    <property name="text">
     <string>Split Vertically</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+2</string>
    </property>
   </action>
  </widget>


### PR DESCRIPTION
Implementation for the horizontal split suggested in #4.

# Description
This change adds
1. A "View" menu option that lets you toggle between horizontal and vertical splitting the input/output boxes
2. Toggle between them with ctrl+1/ctrl+2
2. Saving & restoring this split preference across restarts
3. Saving & restoring window geometry (size, position) across restarts
4. Add `bind()` template which is `connect()` plus the initial update on startup. To get a bit closer to a proper property binding programming experience.

![Screenshot 2021-05-24 at 11 03 35](https://user-images.githubusercontent.com/198639/119332370-64541580-bc80-11eb-9017-02f236c29602.png)
(Note: The "Enter Fullscreen" menu item is something added by macOS to all View menus in all applications.)