### PR TITLE
Add a speed indicator in the status bar

### DIFF
--- a/src/MarianInterface.cpp
+++ b/src/MarianInterface.cpp
@@ -126,7 +126,7 @@ MarianInterface::MarianInterface(QObject *parent)
                         // Calculate translation speed in terms of words per second
                         double words = num_words.get();
                         std::chrono::duration<double> elapsed_seconds = end-start;
-                        int translationSpeed = std::ceil(words/elapsed_seconds.count());
+                        int translationSpeed = std::ceil(words/elapsed_seconds.count()); // @TODO this could probably be done in the service in the future
                         emit translationReady(QString::fromStdString(response.target.text), translationSpeed);
                     } else {
                         // TODO: What? Raise error? Set model_ to ""?

--- a/src/MarianInterface.h
+++ b/src/MarianInterface.h
@@ -35,7 +35,7 @@ public:
     void setModel(QString path_to_model_dir, const translateLocally::marianSettings& settings);
     void translate(QString in);
 signals:
-    void translationReady(QString translation);
+    void translationReady(QString translation, int);
     void pendingChanged(bool isBusy);
     void error(QString message);
 };

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -38,7 +38,9 @@ MainWindow::MainWindow(QWidget *parent)
     this->setWindowIcon(icon);
 
     // Create the status bar
+    ui_->statusbar->addWidget(ui_->speedDisplay);
     ui_->statusbar->addPermanentWidget(ui_->pendingIndicator);
+    ui_->speedDisplay->hide();
     ui_->pendingIndicator->hide();
 
     // Hide download progress bar
@@ -66,10 +68,16 @@ MainWindow::MainWindow(QWidget *parent)
     // Set up the connection to the translator
     connect(translator_.get(), &MarianInterface::pendingChanged, ui_->pendingIndicator, &QProgressBar::setVisible);
     connect(translator_.get(), &MarianInterface::error, this, &MainWindow::popupError);
-    connect(translator_.get(), &MarianInterface::translationReady, this, [&](QString translation) {
+    connect(translator_.get(), &MarianInterface::translationReady, this, [&](QString translation, int speed) {
         ui_->outputBox->setText(translation);
         ui_->translateAction->setEnabled(true); // Re-enable button after translation is done
         ui_->translateButton->setEnabled(true);
+        if (speed > 0) { // Display the translation speed only if it's > 0. This prevents the user seeing weird number if pressed translate with empty input
+            ui_->speedDisplay->setText(QString("Translation speed: ") + QString::fromStdString(std::to_string(speed)) + QString(" words per second."));
+            ui_->speedDisplay->setVisible(true);
+        } else {
+            ui_->speedDisplay->setVisible(false);
+        }
     });
 
     // Queue translation when user has stopped typing for a bit

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -73,7 +73,7 @@ MainWindow::MainWindow(QWidget *parent)
         ui_->translateAction->setEnabled(true); // Re-enable button after translation is done
         ui_->translateButton->setEnabled(true);
         if (speed > 0) { // Display the translation speed only if it's > 0. This prevents the user seeing weird number if pressed translate with empty input
-            ui_->speedDisplay->setText(QString("Translation speed: ") + QString::fromStdString(std::to_string(speed)) + QString(" words per second."));
+            ui_->speedDisplay->setText(QString("Translation speed: %1 words per second.").arg(speed));
             ui_->speedDisplay->setVisible(true);
         } else {
             ui_->speedDisplay->setVisible(false);

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -67,6 +67,31 @@
       </layout>
      </widget>
     </item>
+    <item row="2" column="0">
+     <widget class="QProgressBar" name="pendingIndicator">
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <property name="maximumSize">
+       <size>
+        <width>100</width>
+        <height>16777215</height>
+       </size>
+      </property>
+      <property name="toolTip">
+       <string>Translating…</string>
+      </property>
+      <property name="maximum">
+       <number>0</number>
+      </property>
+      <property name="value">
+       <number>-1</number>
+      </property>
+     </widget>
+    </item>
     <item row="0" column="0">
      <layout class="QVBoxLayout" name="verticalLayout">
       <item>
@@ -151,28 +176,10 @@
       </item>
      </layout>
     </item>
-    <item row="2" column="0">
-     <widget class="QProgressBar" name="pendingIndicator">
-      <property name="sizePolicy">
-       <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-        <horstretch>0</horstretch>
-        <verstretch>0</verstretch>
-       </sizepolicy>
-      </property>
-      <property name="maximumSize">
-       <size>
-        <width>100</width>
-        <height>16777215</height>
-       </size>
-      </property>
-      <property name="toolTip">
-       <string>Translating…</string>
-      </property>
-      <property name="maximum">
-       <number>0</number>
-      </property>
-      <property name="value">
-       <number>-1</number>
+    <item row="3" column="0">
+     <widget class="QLabel" name="speedDisplay">
+      <property name="text">
+       <string>TextLabel</string>
       </property>
      </widget>
     </item>


### PR DESCRIPTION
I'm not sure how to avoid the string copy when counting words without a major refactoring? Any ideas, could I do it better?
![Screenshot_20210524_170742](https://user-images.githubusercontent.com/2027221/119375325-97170180-bcb2-11eb-87d0-e440e78a65f0.png)
