### PR TITLE
Add LibArchive dependency as an ExternalProject

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,11 +15,6 @@ set(CMAKE_AUTORCC ON)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-if(APPLE) # When on MacOS, we have a non-standard libarchive location because we get it via brew
-#  This attempts to fix a bug, but in fact doesn't do anything.
-#  set(CMAKE_OSX_DEPLOYMENT_TARGET "10.9" CACHE STRING "Minimum OS X deployment version")
-  set(LibArchive_INCLUDE_DIR "/usr/local/opt/libarchive/include")
-endif(APPLE)
 #MSVC can't seem to pick up correct flags otherwise:
 if(MSVC)
   add_definitions(-DUSE_SSE2=1) # Supposed to fix something in the sse_mathfun.h but not sure it does
@@ -49,14 +44,28 @@ message("Building ${PROJECT_NAME}-${PROJECT_VERSION_STRING_FULL}")
 #    endif()
 #endif()
 
-find_package(LibArchive REQUIRED)
-find_package(Threads REQUIRED) # Cross-platform compatible way to get threads?
-if(LibArchive_FOUND)
-    list (APPEND ${INCLUDE_DIRECTORIES} ${LibArchive_INCLUDE_DIRS})
-else(LibArchive_FOUND)
-  MESSAGE(FATAL_ERROR "Could not find the libarchive library and development files.")
-endif( LibArchive_FOUND )
+include(ExternalProject)
+ExternalProject_Add(project_archive
+  PREFIX deps/libarchive-3.5.1
+  URL http://libarchive.org/downloads/libarchive-3.5.1.tar.gz
+  CMAKE_ARGS
+    -DCMAKE_TOOLCHAIN_FILE:FILEPATH=${TOOLCHAIN_FILE}
+    -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR>
+    -DCMAKE_BUILD_TYPE:STRING=Release 
+    -DENABLE_NETTLE:BOOL=OFF
+    -DENABLE_ICONV:BOOL=OFF
+    -DENABLE_CPIO:BOOL=OFF
+    -DENABLE_TEST:BOOL=OFF
+    -DENABLE_ACL:BOOL=OFF
+  BINARY_DIR deps/libarchive-3.5.1/build
+  INSTALL_DIR deps/libarchive-3.5.1/build
+)
 
+ExternalProject_Get_Property(project_archive INSTALL_DIR)
+set(LibArchive_INCLUDE_DIR ${INSTALL_DIR}/include)
+set(LibArchive_LIBRARIES ${INSTALL_DIR}/lib/libarchive.a)
+
+find_package(Threads REQUIRED) # Cross-platform compatible way to get threads?
 find_package(QT NAMES Qt6 Qt5 COMPONENTS Core Gui PrintSupport Widgets LinguistTools Network DBus Svg REQUIRED)
 find_package(Qt${QT_VERSION_MAJOR} COMPONENTS Core Gui PrintSupport Widgets LinguistTools Network DBus Svg REQUIRED)
 
@@ -176,6 +185,8 @@ set(LINK_LIBRARIES
     ${CMAKE_DL_LIBS}) # On unix necessary sometimes
 
 # Reserver the translateLocally name for the MacOS and Windows (potentially) executables. Rename the unix executable to that
+add_dependencies(translateLocally-bin project_archive)
+target_include_directories(translateLocally-bin PRIVATE ${LibArchive_INCLUDE_DIR})
 target_link_libraries(translateLocally-bin PRIVATE ${LINK_LIBRARIES})
 set_target_properties(translateLocally-bin PROPERTIES OUTPUT_NAME translateLocally)
 
@@ -229,9 +240,9 @@ endif(UNIX)
 
 if(APPLE) # Apple specific installation of the app
   # Add the .app Target
+  add_dependencies(translateLocally project_archive)
   target_link_libraries(translateLocally PRIVATE ${LINK_LIBRARIES})
   # When on MacOS, we have a non-standard libarchive location because we get it via brew
-  target_include_directories(translateLocally-bin PRIVATE ${LibArchive_INCLUDE_DIR})
   target_include_directories(translateLocally PRIVATE ${LibArchive_INCLUDE_DIR})
   # produce .dmg
   include(macdeployqt)


### PR DESCRIPTION
This change adds libarchive as an external cmake project to work around having to install it as a separate dependency when compiling.

Note: this change does not remove the installation of libarchive(-dev) from the Github workflows.