### PR TITLE
Polish fetch remote list

### DIFF
--- a/src/ModelManager.h
+++ b/src/ModelManager.h
@@ -112,7 +112,21 @@ public:
      */
     void updateAvailableModels(); // remote - local
 
+    /**
+     * @brief whether or not fetchRemoteModels is in progress
+     */
+    inline bool isFetchingRemoteModels() const {
+        return isFetchingRemoteModels_;
+    }
+
 public slots:
+    /**
+     * @Brief downloads list of available remote models. On start, fetchingRemoteModels is emitted
+     * (unless a fetch request is already in progress). When the request is
+     * finished (either successfully or not) fetchedRemoteModels is emitted.
+     * On success localModelsChanged() will also be emitted as fetching remote
+     * models causes updates on the outdated() status of local models.
+     */
     void fetchRemoteModels();
     
 private:
@@ -134,9 +148,11 @@ private:
     QList<Model> updatedModels_;
 
     QNetworkAccessManager *nam_;
+    bool isFetchingRemoteModels_;
 
 signals:
-    void fetchedRemoteModels();
+    void fetchingRemoteModels();
+    void fetchedRemoteModels(); // when finished fetching (might be error)
     void localModelsChanged();
     void error(QString);
 };

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -217,7 +217,7 @@ void MainWindow::updateLocalModels() {
     ui_->localModels->insertSeparator(ui_->localModels->count());
     if (models_.getRemoteModels().empty()) {
         if (models_.isFetchingRemoteModels()) {
-            addDisabledItem(ui_->localModels, tr("Downloading remote model list…"));
+            addDisabledItem(ui_->localModels, tr("Downloading model list…"));
         } else {
             ui_->localModels->addItem(tr("Download models…"), Action::FetchRemoteModels);
         }


### PR DESCRIPTION
- Make fetchRemoteModels reentrant (I think that's the term? Meaning you can call it multiple times it will still do only one request at a time)
- Replace the "Download models…" option with a "Downloading model list…" message while we're downloading said list.

This should fix #42.