### PR TITLE
Add User-Agent header to http requests

### DIFF
--- a/src/ModelManager.cpp
+++ b/src/ModelManager.cpp
@@ -1,4 +1,5 @@
 #include "ModelManager.h"
+#include "Network.h"
 #include <QSettings>
 #include <QDir>
 #include <QDirIterator>
@@ -8,7 +9,6 @@
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QJsonArray>
-#include <QNetworkAccessManager>
 #include <QNetworkReply>
 #include <iostream>
 // libarchive
@@ -18,7 +18,7 @@
 
 ModelManager::ModelManager(QObject *parent)
     : QObject(parent)
-    , nam_(new QNetworkAccessManager(this))
+    , network_(new Network(this))
     , isFetchingRemoteModels_(false)
 {
     // Create/Load Settings and create a directory on the first run. Use mock QSEttings, because we want nativeFormat, but we don't want ini on linux.
@@ -299,7 +299,7 @@ void ModelManager::fetchRemoteModels() {
 
     QUrl url("http://data.statmt.org/bergamot/models/models.json");
     QNetworkRequest request(url);
-    QNetworkReply *reply = nam_->get(request);
+    QNetworkReply *reply = network_->get(request);
     connect(reply, &QNetworkReply::finished, this, [=] {
         switch (reply->error()) {
             case QNetworkReply::NoError:

--- a/src/ModelManager.h
+++ b/src/ModelManager.h
@@ -4,9 +4,9 @@
 #include <QList>
 #include <QFuture>
 #include <iostream>
+#include "Network.h"
 #include "types.h"
 
-class QNetworkAccessManager;
 
 namespace translateLocally {
     namespace models {
@@ -147,7 +147,7 @@ private:
     QList<Model> newModels_;
     QList<Model> updatedModels_;
 
-    QNetworkAccessManager *nam_;
+    Network *network_;
     bool isFetchingRemoteModels_;
 
 signals:

--- a/src/Network.cpp
+++ b/src/Network.cpp
@@ -1,6 +1,7 @@
 #include "Network.h"
 #include <QNetworkReply>
 #include <QTemporaryFile>
+#include <QCoreApplication>
 
 Network::Network(QObject *parent)
     : QObject(parent)
@@ -10,8 +11,16 @@ Network::Network(QObject *parent)
 #endif
 }
 
+QNetworkReply* Network::get(QNetworkRequest request) {
+    request.setRawHeader("User-Agent", QString("%1/%2")
+        .arg(QCoreApplication::applicationName())
+        .arg(QCoreApplication::applicationVersion())
+        .toUtf8());
+    return nam_->get(request);
+}
+
 QNetworkReply* Network::downloadFile(QUrl url, QFile *dest) {
-    QNetworkReply *reply = nam_->get(QNetworkRequest(url));
+    QNetworkReply *reply = get(QNetworkRequest(url));
     
     // Open in read/write so we can easily read the data when handling the
     // downloadComplete signal.

--- a/src/Network.h
+++ b/src/Network.h
@@ -10,8 +10,29 @@ class Network : public QObject {
     Q_OBJECT
 public:
     Network(QObject *parent);
-    QNetworkReply *downloadFile(QUrl url);
+    
+    /**
+     * Wrapper around QNetworkAccessManager::get that adds a User-Agent header.
+     * Used by this class, but also useful on its own.
+     */
+    QNetworkReply *get(QNetworkRequest request);
+
+    /**
+     * Download a file to a destination on disk. Useful for skipping loading the
+     * file in memory. The `downloadComplete(QFile,QString)` signal will be 
+     * emitted with a pointer to the file and a suggested filename. During 
+     * download the `progressBar(qint64,qint64)` signal will be emitted.
+     */ 
     QNetworkReply *downloadFile(QUrl url, QFile* dest);
+
+    /**
+     * Overloaded version of `downloadFile(QUrl,QFile)` that downloads to a
+     * `QTemporaryFile`. The file will be deleted when the returned 
+     * `QNetworkReply` object is destroyed. But you can change this by changing
+     * the file's parent.
+     */
+    QNetworkReply *downloadFile(QUrl url);
+    
 private:
     std::unique_ptr<QNetworkAccessManager> nam_;
 


### PR DESCRIPTION
This adds a User-Agent header on all requests. The only use case for this change should be analytics:
- differentiate between browser, translateLocally, and any other programs that might be downloading models. (You can already do this right now by looking at the lack of a User-Agent header 😛)
- to get an idea which versions of translateLocally are in use, at least with the audience that downloads/updates models.