### PR TITLE
Manage local models through application

### DIFF
--- a/src/MarianInterface.cpp
+++ b/src/MarianInterface.cpp
@@ -149,6 +149,11 @@ QString const &MarianInterface::model() const {
 void MarianInterface::setModel(QString path_to_model_dir, const translateLocally::marianSettings &settings) {
     model_ = path_to_model_dir;
 
+    // Empty model string means just "unload" the model. We don't do that (yet),
+    // instead this just causes translate(QString) to no longer work.
+    if (model_.isEmpty())
+        return;
+
     // move my shared_ptr from stack to heap
     QMutexLocker locker(&lock_);
     std::unique_ptr<ModelDescription> model(new ModelDescription{model_.toStdString(), settings});

--- a/src/ModelManager.cpp
+++ b/src/ModelManager.cpp
@@ -407,16 +407,29 @@ QVariant ModelManager::data(const QModelIndex &index, int role) const {
     if (index.row() >= localModels_.size())
         return QVariant();
 
-    if (role != Qt::DisplayRole)
-        return QVariant();
-
     Model model = localModels_[index.row()];
 
     switch (index.column()) {
         case Column::Name:
-            return model.modelName;
+            switch (role) {
+                case Qt::DisplayRole:
+                    return model.modelName;
+                default:
+                    return QVariant();
+            }
+
         case Column::Version:
-            return model.localversion;
+            switch (role) {
+                case Qt::DisplayRole:
+                    return model.localversion;
+                case Qt::TextAlignmentRole:
+                    // @TODO figure out how to compile combined flag as below. 
+                    // Error is "can't convert the result to QVariant."
+                    // return Qt::AlignRight | Qt::AlignBaseline;
+                    return Qt::AlignRight;
+                default:
+                    return QVariant();
+            }
     }
 
     return QVariant();

--- a/src/ModelManager.cpp
+++ b/src/ModelManager.cpp
@@ -133,8 +133,9 @@ Model ModelManager::writeModel(QFile *file, QString filename) {
         return Model{};
     }
 
-    // Don't try to delete the no-longer-temporary directry
-    tempDir.setAutoRemove(false);
+    // Only remove the temp directory if we moved a directory within it. Don't 
+    // attempt anything if we moved the whole directory itself.
+    tempDir.setAutoRemove(prefix != tempDir.path());
 
     QJsonObject obj = getModelInfoJsonFromDir(newModelDirPath);
     Q_ASSERT(obj.find("path") != obj.end());

--- a/src/ModelManager.cpp
+++ b/src/ModelManager.cpp
@@ -483,6 +483,14 @@ QList<Model> ModelManager::getUpdatedModels() const {
     return updatedModels_;
 }
 
+Model ModelManager::getModelForPath(QString path) const {
+    for (Model const &model : getInstalledModels())
+        if (model.path == path)
+            return model;
+
+    return Model{};
+}
+
 void ModelManager::updateAvailableModels() {
     newModels_.clear();
     updatedModels_.clear();

--- a/src/ModelManager.cpp
+++ b/src/ModelManager.cpp
@@ -123,7 +123,7 @@ Model ModelManager::writeModel(QFile *file, QString filename) {
     if (!validateModel(prefix)) // validateModel emits its own error() signals (hence validateModel and not isModelValid)
         return Model{};
 
-    QString newModelDirName = QString("%1-%2").arg(filename.split(".tar.gz")[0]).arg(QDateTime::currentSecsSinceEpoch());
+    QString newModelDirName = QString("%1-%2").arg(filename.split(".tar.gz")[0]).arg(QDateTime::currentMSecsSinceEpoch() / 1000);
     QString newModelDirPath = configDir_.absoluteFilePath(newModelDirName);
 
     if (!QDir().rename(prefix, newModelDirPath)) {

--- a/src/ModelManager.cpp
+++ b/src/ModelManager.cpp
@@ -17,7 +17,7 @@
 
 
 ModelManager::ModelManager(QObject *parent)
-    : QObject(parent)
+    : QAbstractTableModel(parent)
     , network_(new Network(this))
     , isFetchingRemoteModels_(false)
 {
@@ -372,4 +372,52 @@ void ModelManager::updateAvailableModels() {
     }
 
     emit localModelsChanged();
+}
+
+int ModelManager::rowCount(const QModelIndex &parent) const {
+    Q_UNUSED(parent);
+
+    return localModels_.size();
+} 
+
+int ModelManager::columnCount(const QModelIndex &parent) const {
+    Q_UNUSED(parent);
+
+    return 2;
+}
+
+QVariant ModelManager::headerData(int section, Qt::Orientation orientation, int role) const {
+    if (role != Qt::DisplayRole)
+        return QVariant();
+
+    if (orientation != Qt::Horizontal)
+        return QVariant();
+
+    switch (section) {
+        case Column::Name:
+            return tr("Name", "translation model name");
+        case Column::Version:
+            return tr("Version", "translation model version");
+        default:
+            return QVariant();
+    }
+}
+
+QVariant ModelManager::data(const QModelIndex &index, int role) const {
+    if (index.row() >= localModels_.size())
+        return QVariant();
+
+    if (role != Qt::DisplayRole)
+        return QVariant();
+
+    Model model = localModels_[index.row()];
+
+    switch (index.column()) {
+        case Column::Name:
+            return model.modelName;
+        case Column::Version:
+            return model.localversion;
+    }
+
+    return QVariant();
 }

--- a/src/ModelManager.cpp
+++ b/src/ModelManager.cpp
@@ -204,7 +204,7 @@ bool ModelManager::insertLocalModel(Model model) {
             position = i + 1;
     }
 
-    beginInsertRows(QModelIndex(), position, position + 1);
+    beginInsertRows(QModelIndex(), position, position);
     localModels_.insert(position, model);
     endInsertRows();
     return true;

--- a/src/ModelManager.cpp
+++ b/src/ModelManager.cpp
@@ -409,6 +409,9 @@ QVariant ModelManager::data(const QModelIndex &index, int role) const {
 
     Model model = localModels_[index.row()];
 
+    if (role == Qt::UserRole)
+        return QVariant::fromValue(model);
+
     switch (index.column()) {
         case Column::Name:
             switch (role) {

--- a/src/ModelManager.cpp
+++ b/src/ModelManager.cpp
@@ -143,6 +143,17 @@ Model ModelManager::writeModel(QFile *file, QString filename) {
     Q_ASSERT(obj.find("path") != obj.end());
 
     Model model = parseModelInfo(obj);
+
+    // Upgrade behaviour: remove any older versions of this model. At least if
+    // the older model is part of the models managed by us. We don't delete
+    // models from the CWD.
+    // Note: Right now there's no check on version. We assume that if writeModel
+    // is called, it either was called from the upgrade path, or the user
+    // intentionally installing an older model through the model manager UI.
+    for (auto &&installed : localModels_)
+        if (installed.isSameModel(model) && isManagedModel(installed))
+            removeModel(installed);
+
     insertLocalModel(model);
     updateAvailableModels();
     

--- a/src/ModelManager.cpp
+++ b/src/ModelManager.cpp
@@ -180,7 +180,7 @@ bool ModelManager::removeModel(Model const &model) {
     if (position == -1)
         return false;
 
-    beginRemoveRows(QModelIndex(), position, position + 1);
+    beginRemoveRows(QModelIndex(), position, position);
     localModels_.removeOne(model);
     endRemoveRows();
     updateAvailableModels();
@@ -205,7 +205,7 @@ bool ModelManager::insertLocalModel(Model model) {
     }
 
     beginInsertRows(QModelIndex(), position, position + 1);
-    localModels_.append(model);
+    localModels_.insert(position, model);
     endInsertRows();
     return true;
 }

--- a/src/ModelManager.cpp
+++ b/src/ModelManager.cpp
@@ -34,6 +34,10 @@ ModelManager::ModelManager(QObject *parent)
     startupLoad();
 }
 
+bool ModelManager::isManagedModel(Model const &model) const {
+    return model.isLocal() && model.path.startsWith(configDir_.absolutePath());
+}
+
 Model ModelManager::writeModel(QFile *file, QString filename) {
     Model newmodel;
 
@@ -45,7 +49,7 @@ Model ModelManager::writeModel(QFile *file, QString filename) {
     
     // Add the model to the local models and emit a signal with its index
     QString newModelDirName = filename.split(".tar.gz")[0];
-    QJsonObject obj = getModelInfoJsonFromDir(configDir_.absolutePath() + QString("/") + newModelDirName);
+    QJsonObject obj = getModelInfoJsonFromDir(configDir_.absoluteFilePath(newModelDirName));
 
     // The function above should have added the path variable. it will error message if it fails.
     if (obj.find("path") == obj.end()) {
@@ -61,7 +65,7 @@ Model ModelManager::writeModel(QFile *file, QString filename) {
 }
 
 bool ModelManager::removeModel(Model const &model) {
-    if (!model.isLocal())
+    if (!isManagedModel(model))
         return false;
 
     QDir modelDir = QDir(model.path);

--- a/src/ModelManager.cpp
+++ b/src/ModelManager.cpp
@@ -39,6 +39,9 @@ Model ModelManager::writeModel(QFile *file, QString filename) {
 
     if (!extractTarGz(file))
         return newmodel;
+
+    if (filename.isEmpty())
+        filename = QFileInfo(*file).fileName();
     
     // Add the model to the local models and emit a signal with its index
     QString newModelDirName = filename.split(".tar.gz")[0];

--- a/src/ModelManager.cpp
+++ b/src/ModelManager.cpp
@@ -102,8 +102,6 @@ Model ModelManager::writeModel(QFile *file, QString filename) {
     if (!extractTarGz(file, tempDir.path(), extracted))
         return Model{};
 
-    qDebug() << "Extracted: " << extracted;
-
     // Assert we extracted at least something.
     if (extracted.isEmpty()) {
         emit error(tr("Did not extract any files from the model archive."));
@@ -113,12 +111,12 @@ Model ModelManager::writeModel(QFile *file, QString filename) {
     // Get the common prefix of all files. In the ideal case, it's the same as
     // tempDir, but the archive might have had it's own sub folder.
     QString prefix = getCommonPrefixPath(extracted);
-    qDebug() << "Common prefix: " << prefix;
-
     if (prefix.isEmpty()) {
         emit error(tr("Could not determine prefix path of extracted model."));
         return Model{};
     }
+
+    Q_ASSERT(prefix.startsWith(tempDir.path()));
 
     // Try determining whether the model is any good before we continue to safe
     // it to a permanent destination
@@ -128,9 +126,6 @@ Model ModelManager::writeModel(QFile *file, QString filename) {
     QString newModelDirName = QString("%1-%2").arg(filename.split(".tar.gz")[0]).arg(QDateTime::currentSecsSinceEpoch());
     QString newModelDirPath = configDir_.absoluteFilePath(newModelDirName);
 
-    qDebug() << "Rename " << prefix << " to " << newModelDirPath;
-
-    // Q_ASSERT(prefix exists in tempDir)
     if (!QDir().rename(prefix, newModelDirPath)) {
         emit error(tr("Could not move extracted model from %1 to %2.").arg(tempDir.path()).arg(newModelDirPath));
         return Model{};

--- a/src/ModelManager.cpp
+++ b/src/ModelManager.cpp
@@ -39,7 +39,7 @@ namespace {
             // If we found a mismatch, we found a substring in it that's a
             // shorter common prefix.
             if (offsets.first != prefix.end())
-                prefix = it->sliced(0, offsets.second - it->begin());
+                prefix = it->left(offsets.second - it->begin());
         }
 
         // prefix.section("/", 0, -1)?

--- a/src/ModelManager.h
+++ b/src/ModelManager.h
@@ -110,6 +110,12 @@ public:
     Model writeModel(QFile *file, QString filename = QString());
     bool removeModel(Model const &model);
 
+    /**
+     * @Brief is this model managed by ModelManager (i.e. created with 
+     * writeModel()).
+     */
+    bool isManagedModel(Model const &model) const;
+
     QList<Model> getInstalledModels() const;
     QList<Model> getRemoteModels() const;
     QList<Model> getUpdatedModels() const;

--- a/src/ModelManager.h
+++ b/src/ModelManager.h
@@ -159,8 +159,8 @@ public slots:
 private:
     void startupLoad();
     void scanForModels(QString path);
-    bool extractTarGz(QFile *file);
-    bool extractTarGzInCurrentPath(QFile *file);
+    bool extractTarGz(QFile *file, QDir const &destination, QStringList &files);
+    bool extractTarGzInCurrentPath(QFile *file, QStringList &files);
     Model parseModelInfo(QJsonObject& obj, translateLocally::models::Location type=translateLocally::models::Location::Local);
     void parseRemoteModels(QJsonObject obj);
     QJsonObject getModelInfoJsonFromDir(QString dir);

--- a/src/ModelManager.h
+++ b/src/ModelManager.h
@@ -85,6 +85,13 @@ struct Model {
         return localversion<remoteversion || localAPI < remoteAPI;
     }
 
+    // Is-equal operator for removing models from list
+    inline bool operator==(const Model &other) const {
+        return isSameModel(other)
+            && (!isLocal() || path == other.path)
+            && (!isRemote() || url == other.url);
+    }
+
     // Debug
     inline void print() const {
         std::cerr << "shortName: " << shortName.toStdString() << " modelName: " << modelName.toStdString() <<
@@ -101,6 +108,7 @@ class ModelManager : public QAbstractTableModel {
 public:
     ModelManager(QObject *parent);
     Model writeModel(QFile *file, QString filename);
+    bool removeModel(Model const &model);
 
     QList<Model> getInstalledModels() const;
     QList<Model> getRemoteModels() const;

--- a/src/ModelManager.h
+++ b/src/ModelManager.h
@@ -107,7 +107,7 @@ class ModelManager : public QAbstractTableModel {
         Q_OBJECT
 public:
     ModelManager(QObject *parent);
-    Model writeModel(QFile *file, QString filename);
+    Model writeModel(QFile *file, QString filename = QString());
     bool removeModel(Model const &model);
 
     QList<Model> getInstalledModels() const;

--- a/src/ModelManager.h
+++ b/src/ModelManager.h
@@ -3,6 +3,7 @@
 #include <QDir>
 #include <QList>
 #include <QFuture>
+#include <QAbstractTableModel>
 #include <iostream>
 #include "Network.h"
 #include "types.h"
@@ -95,7 +96,7 @@ struct Model {
 
 Q_DECLARE_METATYPE(Model)
 
-class ModelManager : public QObject {
+class ModelManager : public QAbstractTableModel {
         Q_OBJECT
 public:
     ModelManager(QObject *parent);
@@ -118,6 +119,18 @@ public:
     inline bool isFetchingRemoteModels() const {
         return isFetchingRemoteModels_;
     }
+
+    enum Column {
+        Name,
+        Version
+    };
+
+    Q_ENUM(Column);
+
+    int rowCount(const QModelIndex &parent = QModelIndex()) const;
+    int columnCount(const QModelIndex &parent = QModelIndex()) const;
+    QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const;
+    QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const;
 
 public slots:
     /**

--- a/src/ModelManager.h
+++ b/src/ModelManager.h
@@ -116,6 +116,13 @@ public:
      */
     bool isManagedModel(Model const &model) const;
 
+    /**
+     * @Brief returns model from getInstalledModels() that matches the path.
+     * Useful for checking whether a model for which you've saved the path
+     * is still available.
+     */
+    Model getModelForPath(QString path) const; 
+
     QList<Model> getInstalledModels() const;
     QList<Model> getRemoteModels() const;
     QList<Model> getUpdatedModels() const;

--- a/src/ModelManager.h
+++ b/src/ModelManager.h
@@ -165,6 +165,7 @@ private:
     void parseRemoteModels(QJsonObject obj);
     QJsonObject getModelInfoJsonFromDir(QString dir);
     bool insertLocalModel(Model model);
+    bool validateModel(QString path);
 
     QDir configDir_;
 

--- a/src/TranslatorSettingsDialog.cpp
+++ b/src/TranslatorSettingsDialog.cpp
@@ -2,6 +2,7 @@
 #include "ui_TranslatorSettingsDialog.h"
 #include <thread>
 #include <QDesktopServices>
+#include <QFileDialog>
 
 TranslatorSettingsDialog::TranslatorSettingsDialog(QWidget *parent, Settings *settings, ModelManager *modelManager)
 : QDialog(parent)
@@ -66,5 +67,17 @@ void TranslatorSettingsDialog::on_actionDeleteModel_triggered()
     for (auto index : ui_->localModelTable->selectionModel()->selectedIndexes()) {
         Model model = modelManager_->data(index, Qt::UserRole).value<Model>();
         modelManager_->removeModel(model);
+    }
+}
+
+void TranslatorSettingsDialog::on_importModelButton_pressed() {
+    QStringList paths = QFileDialog::getOpenFileNames(this,
+        tr("Open Translation model"),
+        QString(),
+        tr("Packaged translation model (*.tar.gz)"));
+
+    for (QString const &path : paths) {
+        QFile file = QFile(path);
+        modelManager_->writeModel(&file);
     }
 }

--- a/src/TranslatorSettingsDialog.cpp
+++ b/src/TranslatorSettingsDialog.cpp
@@ -2,7 +2,9 @@
 #include "ui_TranslatorSettingsDialog.h"
 #include <thread>
 #include <QDesktopServices>
+#include <QUrl>
 #include <QFileDialog>
+
 
 TranslatorSettingsDialog::TranslatorSettingsDialog(QWidget *parent, Settings *settings, ModelManager *modelManager)
 : QDialog(parent)
@@ -82,7 +84,7 @@ void TranslatorSettingsDialog::on_importModelButton_pressed() {
         tr("Packaged translation model (*.tar.gz)"));
 
     for (QString const &path : paths) {
-        QFile file = QFile(path);
+        QFile file(path);
         modelManager_->writeModel(&file);
     }
 }

--- a/src/TranslatorSettingsDialog.cpp
+++ b/src/TranslatorSettingsDialog.cpp
@@ -4,6 +4,7 @@
 #include <QDesktopServices>
 #include <QUrl>
 #include <QFileDialog>
+#include <QMessageBox>
 
 
 TranslatorSettingsDialog::TranslatorSettingsDialog(QWidget *parent, Settings *settings, ModelManager *modelManager)
@@ -75,10 +76,21 @@ void TranslatorSettingsDialog::revealSelectedModels()
 
 void TranslatorSettingsDialog::deleteSelectedModels()
 {
-    for (auto index : ui_->localModelTable->selectionModel()->selectedIndexes()) {
+    QList<Model> selection;
+    for (auto index : ui_->localModelTable->selectionModel()->selectedRows(0)) {
         Model model = modelManager_->data(index, Qt::UserRole).value<Model>();
-        modelManager_->removeModel(model);
+        if (modelManager_->isManagedModel(model))
+            selection.append(model);
     }
+
+    if (QMessageBox::question(this,
+            tr("Delete models"),
+            tr("Are you sure you want to delete %n language model(s)?", "", selection.size())
+        ) != QMessageBox::Yes)
+        return;
+
+    for (auto &&model : selection)
+        modelManager_->removeModel(model);
 }
 
 void TranslatorSettingsDialog::importModels() {

--- a/src/TranslatorSettingsDialog.cpp
+++ b/src/TranslatorSettingsDialog.cpp
@@ -28,6 +28,8 @@ TranslatorSettingsDialog::TranslatorSettingsDialog(QWidget *parent, Settings *se
         ui_->coresBox->addItem(QString("%1").arg(option), option);
 
     ui_->localModelTable->setModel(modelManager_);
+    ui_->localModelTable->horizontalHeader()->setSectionResizeMode(ModelManager::Column::Name, QHeaderView::Stretch);
+    ui_->localModelTable->horizontalHeader()->setSectionResizeMode(ModelManager::Column::Version, QHeaderView::ResizeToContents);
 }
 
 TranslatorSettingsDialog::~TranslatorSettingsDialog()

--- a/src/TranslatorSettingsDialog.cpp
+++ b/src/TranslatorSettingsDialog.cpp
@@ -1,6 +1,7 @@
 #include "TranslatorSettingsDialog.h"
 #include "ui_TranslatorSettingsDialog.h"
 #include <thread>
+#include <QDesktopServices>
 
 TranslatorSettingsDialog::TranslatorSettingsDialog(QWidget *parent, Settings *settings, ModelManager *modelManager)
 : QDialog(parent)
@@ -49,4 +50,18 @@ void TranslatorSettingsDialog::on_buttonBox_accepted()
     settings_->cores.setValue(ui_->coresBox->currentData().toUInt());
     settings_->workspace.setValue(ui_->memoryBox->currentData().toUInt());
     settings_->translateImmediately.setValue(ui_->translateImmediatelyCheckbox->isChecked());
+}
+
+
+void TranslatorSettingsDialog::on_actionRevealModel_triggered()
+{
+    for (auto index : ui_->localModelTable->selectionModel()->selectedIndexes()) {
+        Model model = modelManager_->data(index, Qt::UserRole).value<Model>();
+        QDesktopServices::openUrl(QUrl(QString("file://%1").arg(model.path), QUrl::TolerantMode));
+    }
+}
+
+void TranslatorSettingsDialog::on_actionDeleteModel_triggered()
+{
+
 }

--- a/src/TranslatorSettingsDialog.cpp
+++ b/src/TranslatorSettingsDialog.cpp
@@ -63,5 +63,8 @@ void TranslatorSettingsDialog::on_actionRevealModel_triggered()
 
 void TranslatorSettingsDialog::on_actionDeleteModel_triggered()
 {
-
+    for (auto index : ui_->localModelTable->selectionModel()->selectedIndexes()) {
+        Model model = modelManager_->data(index, Qt::UserRole).value<Model>();
+        modelManager_->removeModel(model);
+    }
 }

--- a/src/TranslatorSettingsDialog.cpp
+++ b/src/TranslatorSettingsDialog.cpp
@@ -2,10 +2,11 @@
 #include "ui_TranslatorSettingsDialog.h"
 #include <thread>
 
-TranslatorSettingsDialog::TranslatorSettingsDialog(QWidget *parent, Settings *settings)
+TranslatorSettingsDialog::TranslatorSettingsDialog(QWidget *parent, Settings *settings, ModelManager *modelManager)
 : QDialog(parent)
 , ui_(new Ui::TranslatorSettingsDialog())
 , settings_(settings)
+, modelManager_(modelManager)
 {
     ui_->setupUi(this);
     
@@ -25,6 +26,8 @@ TranslatorSettingsDialog::TranslatorSettingsDialog(QWidget *parent, Settings *se
 
     for (auto option : cores_options)
         ui_->coresBox->addItem(QString("%1").arg(option), option);
+
+    ui_->localModelTable->setModel(modelManager_);
 }
 
 TranslatorSettingsDialog::~TranslatorSettingsDialog()

--- a/src/TranslatorSettingsDialog.h
+++ b/src/TranslatorSettingsDialog.h
@@ -22,11 +22,12 @@ protected:
     void showEvent(QShowEvent *ev);
 
 private slots:
-    void on_buttonBox_accepted();
-    void on_actionRevealModel_triggered();
-    void on_actionDeleteModel_triggered();
-    void on_importModelButton_pressed();
-    void updateModelTableContextMenu(const QItemSelection &selected, const QItemSelection &deselected);
+    void updateSettings();
+    void applySettings();
+    void revealSelectedModels();
+    void deleteSelectedModels();
+    void importModels();
+    void updateModelActions();
 
 private:
     Ui::TranslatorSettingsDialog *ui_;

--- a/src/TranslatorSettingsDialog.h
+++ b/src/TranslatorSettingsDialog.h
@@ -22,6 +22,8 @@ protected:
 
 private slots:
     void on_buttonBox_accepted();
+    void on_actionRevealModel_triggered();
+    void on_actionDeleteModel_triggered();
 
 private:
     Ui::TranslatorSettingsDialog *ui_;

--- a/src/TranslatorSettingsDialog.h
+++ b/src/TranslatorSettingsDialog.h
@@ -24,6 +24,7 @@ private slots:
     void on_buttonBox_accepted();
     void on_actionRevealModel_triggered();
     void on_actionDeleteModel_triggered();
+    void on_importModelButton_pressed();
 
 private:
     Ui::TranslatorSettingsDialog *ui_;

--- a/src/TranslatorSettingsDialog.h
+++ b/src/TranslatorSettingsDialog.h
@@ -3,6 +3,7 @@
 
 #include <QDialog>
 #include "Settings.h"
+#include "ModelManager.h"
 
 namespace Ui {
 class TranslatorSettingsDialog;
@@ -13,7 +14,7 @@ class TranslatorSettingsDialog : public QDialog
     Q_OBJECT
 
 public:
-    explicit TranslatorSettingsDialog(QWidget *parent, Settings *settings);
+    explicit TranslatorSettingsDialog(QWidget *parent, Settings *settings, ModelManager *modelManager);
     ~TranslatorSettingsDialog();
 
 protected:
@@ -25,6 +26,7 @@ private slots:
 private:
     Ui::TranslatorSettingsDialog *ui_;
     Settings *settings_;
+    ModelManager *modelManager_;
 };
 
 #endif // TRANSLATORSETTINGS_H

--- a/src/TranslatorSettingsDialog.h
+++ b/src/TranslatorSettingsDialog.h
@@ -2,6 +2,7 @@
 #define TRANSLATORSETTINGS_H
 
 #include <QDialog>
+#include <QItemSelection>
 #include "Settings.h"
 #include "ModelManager.h"
 
@@ -25,6 +26,7 @@ private slots:
     void on_actionRevealModel_triggered();
     void on_actionDeleteModel_triggered();
     void on_importModelButton_pressed();
+    void updateModelTableContextMenu(const QItemSelection &selected, const QItemSelection &deselected);
 
 private:
     Ui::TranslatorSettingsDialog *ui_;

--- a/src/TranslatorSettingsDialog.ui
+++ b/src/TranslatorSettingsDialog.ui
@@ -121,12 +121,20 @@
        </property>
        <item>
         <widget class="QTableView" name="localModelTable">
+         <property name="contextMenuPolicy">
+          <enum>Qt::ActionsContextMenu</enum>
+         </property>
          <property name="selectionBehavior">
           <enum>QAbstractItemView::SelectRows</enum>
          </property>
          <property name="showGrid">
           <bool>false</bool>
          </property>
+         <attribute name="verticalHeaderVisible">
+          <bool>false</bool>
+         </attribute>
+         <addaction name="actionRevealModel"/>
+         <addaction name="actionDeleteModel"/>
         </widget>
        </item>
        <item>
@@ -168,6 +176,22 @@
     </widget>
    </item>
   </layout>
+  <action name="actionRevealModel">
+   <property name="text">
+    <string>Reveal folder</string>
+   </property>
+  </action>
+  <action name="actionDeleteModel">
+   <property name="text">
+    <string>Delete</string>
+   </property>
+   <property name="shortcut">
+    <string>Del</string>
+   </property>
+   <property name="shortcutContext">
+    <enum>Qt::WidgetShortcut</enum>
+   </property>
+  </action>
  </widget>
  <resources/>
  <connections>
@@ -178,8 +202,8 @@
    <slot>accept()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>20</x>
-     <y>20</y>
+     <x>32</x>
+     <y>354</y>
     </hint>
     <hint type="destinationlabel">
      <x>20</x>
@@ -194,8 +218,8 @@
    <slot>reject()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>20</x>
-     <y>20</y>
+     <x>32</x>
+     <y>354</y>
     </hint>
     <hint type="destinationlabel">
      <x>20</x>

--- a/src/TranslatorSettingsDialog.ui
+++ b/src/TranslatorSettingsDialog.ui
@@ -23,7 +23,7 @@
       <attribute name="title">
        <string>Behaviour</string>
       </attribute>
-      <layout class="QVBoxLayout" name="verticalLayout">
+      <layout class="QVBoxLayout" name="verticalLayout_1">
        <property name="leftMargin">
         <number>8</number>
        </property>
@@ -106,7 +106,7 @@
       <attribute name="title">
        <string>Languages</string>
       </attribute>
-      <layout class="QVBoxLayout" name="verticalLayout">
+      <layout class="QVBoxLayout" name="verticalLayout_3">
        <property name="leftMargin">
         <number>8</number>
        </property>

--- a/src/TranslatorSettingsDialog.ui
+++ b/src/TranslatorSettingsDialog.ui
@@ -6,63 +6,155 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>300</width>
-    <height>244</height>
+    <width>362</width>
+    <height>370</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Settings</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
-   <item alignment="Qt::AlignTop">
-    <widget class="QGroupBox" name="behaviourGroup">
-     <property name="title">
-      <string>Behaviour</string>
+   <item>
+    <widget class="QTabWidget" name="tabWidget">
+     <property name="currentIndex">
+      <number>0</number>
      </property>
-     <layout class="QVBoxLayout" name="verticalLayout_2">
-      <item alignment="Qt::AlignTop">
-       <widget class="QCheckBox" name="translateImmediatelyCheckbox">
-        <property name="text">
-         <string>Translate as I type</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item alignment="Qt::AlignTop">
-    <widget class="QGroupBox" name="resourceGroup">
-     <property name="title">
-      <string>Resource usage</string>
-     </property>
-     <layout class="QFormLayout" name="formLayout_2">
-      <item row="0" column="0">
-       <widget class="QLabel" name="coresLbl">
-        <property name="text">
-         <string>Threads</string>
-        </property>
-        <property name="buddy">
-         <cstring>coresBox</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="QComboBox" name="memoryBox"/>
-      </item>
-      <item row="0" column="1">
-       <widget class="QComboBox" name="coresBox"/>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="memoryLbl">
-        <property name="text">
-         <string>Memory per thread</string>
-        </property>
-        <property name="buddy">
-         <cstring>memoryBox</cstring>
-        </property>
-       </widget>
-      </item>
-     </layout>
+     <widget class="QWidget" name="behaviorTab">
+      <attribute name="title">
+       <string>Behaviour</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout">
+       <property name="leftMargin">
+        <number>8</number>
+       </property>
+       <property name="topMargin">
+        <number>8</number>
+       </property>
+       <property name="rightMargin">
+        <number>8</number>
+       </property>
+       <property name="bottomMargin">
+        <number>8</number>
+       </property>
+       <item>
+        <widget class="QGroupBox" name="behaviourGroup">
+         <property name="title">
+          <string>Behaviour</string>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_2">
+          <item alignment="Qt::AlignTop">
+           <widget class="QCheckBox" name="translateImmediatelyCheckbox">
+            <property name="text">
+             <string>Translate as I type</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <widget class="QGroupBox" name="resourceGroup">
+         <property name="title">
+          <string>Resource usage</string>
+         </property>
+         <layout class="QFormLayout" name="formLayout_2">
+          <item row="0" column="0">
+           <widget class="QLabel" name="coresLbl">
+            <property name="text">
+             <string>Threads</string>
+            </property>
+            <property name="buddy">
+             <cstring>coresBox</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QComboBox" name="memoryBox"/>
+          </item>
+          <item row="0" column="1">
+           <widget class="QComboBox" name="coresBox"/>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="memoryLbl">
+            <property name="text">
+             <string>Memory per thread</string>
+            </property>
+            <property name="buddy">
+             <cstring>memoryBox</cstring>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="modelsTab">
+      <attribute name="title">
+       <string>Languages</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout">
+       <property name="leftMargin">
+        <number>8</number>
+       </property>
+       <property name="topMargin">
+        <number>8</number>
+       </property>
+       <property name="rightMargin">
+        <number>8</number>
+       </property>
+       <property name="bottomMargin">
+        <number>8</number>
+       </property>
+       <item>
+        <widget class="QTableView" name="localModelTable">
+         <property name="selectionBehavior">
+          <enum>QAbstractItemView::SelectRows</enum>
+         </property>
+         <property name="showGrid">
+          <bool>false</bool>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout">
+         <item>
+          <widget class="QPushButton" name="pushButton">
+           <property name="text">
+            <string>Import model…</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="horizontalSpacer">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+        </layout>
+       </item>
+      </layout>
+     </widget>
     </widget>
    </item>
    <item>

--- a/src/TranslatorSettingsDialog.ui
+++ b/src/TranslatorSettingsDialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>362</width>
-    <height>370</height>
+    <width>450</width>
+    <height>400</height>
    </rect>
   </property>
   <property name="windowTitle">

--- a/src/TranslatorSettingsDialog.ui
+++ b/src/TranslatorSettingsDialog.ui
@@ -147,6 +147,16 @@
           </widget>
          </item>
          <item>
+          <widget class="QPushButton" name="deleteModelButton">
+           <property name="enabled">
+            <bool>false</bool>
+           </property>
+           <property name="text">
+            <string>Delete</string>
+           </property>
+          </widget>
+         </item>
+         <item>
           <spacer name="horizontalSpacer">
            <property name="orientation">
             <enum>Qt::Horizontal</enum>

--- a/src/TranslatorSettingsDialog.ui
+++ b/src/TranslatorSettingsDialog.ui
@@ -140,7 +140,7 @@
        <item>
         <layout class="QHBoxLayout" name="horizontalLayout">
          <item>
-          <widget class="QPushButton" name="pushButton">
+          <widget class="QPushButton" name="importModelButton">
            <property name="text">
             <string>Import model…</string>
            </property>

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -257,11 +257,13 @@ void MainWindow::updateSelectedModel() {
     }
 
     // Normal behaviour: find the item that matches the local model
-    for (int i = 0; i < ui_->localModels->count(); ++i) {
-        QVariant item = ui_->localModels->itemData(i);
-        if (item.canConvert<Model>() && item.value<Model>().path == settings_.translationModel()) {
-            ui_->localModels->setCurrentIndex(i);
-            return;
+    if (settings_.translationModel() != "") {
+        for (int i = 0; i < ui_->localModels->count(); ++i) {
+            QVariant item = ui_->localModels->itemData(i);
+            if (item.canConvert<Model>() && item.value<Model>().path == settings_.translationModel()) {
+                ui_->localModels->setCurrentIndex(i);
+                return;
+            }
         }
     }
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -55,7 +55,7 @@ MainWindow::MainWindow(QWidget *parent)
     updateLocalModels();
 
     // If we have preferred model, but it no longer exists on disk, reset it to empty
-    if (!settings_.translationModel().isEmpty() && !QDir(settings_.translationModel()).exists())
+    if (!settings_.translationModel().isEmpty() && !models_.getModelForPath(settings_.translationModel()).isLocal())
         settings_.translationModel.setValue("");
 
     // If no model is preferred, load the first available one.

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -280,7 +280,11 @@ void MainWindow::translate(QString const &text) {
     ui_->translateAction->setEnabled(false); //Disable the translate button before the translation finishes
     ui_->translateButton->setEnabled(false);
     if (translator_->model().isEmpty()) {
-        popupError(tr("You need to download a translation model first. Do that through the drop down menu on top."));
+        if (models_.getInstalledModels().isEmpty()) {
+            popupError(tr("You need to download a translation model first. You can do that through the drop down menu on top."));
+        } else {
+            popupError(tr("You need to pick a translation model first. You can do that through the drop down menu on top."));
+        }
     } else {
         translator_->translate(text);
     }    

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -32,7 +32,7 @@ MainWindow::MainWindow(QWidget *parent)
     , ui_(new Ui::MainWindow)
     , settings_(this)
     , models_(this)
-    , translatorSettingsDialog_(this, &settings_)
+    , translatorSettingsDialog_(this, &settings_, &models_)
     , network_(this)
     , translator_(new MarianInterface(this))
 {

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -54,6 +54,10 @@ MainWindow::MainWindow(QWidget *parent)
 
     updateLocalModels();
 
+    // If we have preferred model, but it no longer exists on disk, reset it to empty
+    if (!settings_.translationModel().isEmpty() && !QDir(settings_.translationModel()).exists())
+        settings_.translationModel.setValue("");
+
     // If no model is preferred, load the first available one.
     if (settings_.translationModel().isEmpty() && !models_.getInstalledModels().empty())
         settings_.translationModel.setValue(models_.getInstalledModels().first().path);
@@ -281,19 +285,11 @@ void MainWindow::translate(QString const &text) {
 }
 
 void MainWindow::resetTranslator() {
-    // Don't do anything if there is no model selected.
-    if (settings_.translationModel().isEmpty())
-        return;
-
-    // Don't do anything if the path given isn't valid (e.g. user deleted
-    // model from disk but it is still mentioned in Settings)
-    if (!QDir(settings_.translationModel()).exists())
-        return;
-
+    // Note: settings_.translationModel() can be empty string, meaning unload the current model
     translator_->setModel(settings_.translationModel(), settings_.marianSettings());
     
     // Schedule re-translation immediately if we're in automatic mode.
-    if (settings_.translateImmediately())
+    if (!settings_.translationModel().isEmpty() && settings_.translateImmediately())
         translate();
 }
 

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>493</width>
+    <width>500</width>
     <height>450</height>
    </rect>
   </property>


### PR DESCRIPTION
Solving #45.

Idea is to:
- [x] Add a table to the settings dialog to see & delete local models
  - [x] only the ones in .config/translateLocally can be deleted. Do not attempt to delete models found in `pwd`.
  - [x] Make delete option prominent so the intention of that table becomes immediately clear  
_I'm thinking adding a column with a delete button per row, but might end up with a button at the bottom of the table that is only enabled if deletable modes are selected. Like how the context menu works. Because of space._
- [x] Add an import button to load (copy) local models into the local "library" (the .config/translateLocally folder)
  - [x] validate before importing (check whether there is a model_json file?)  
_partially done, model is not imported but extracted files stay_

This won't affect:
- Reading local models from the start-up directory. That should keep working. Those models should not be imported into the local library.