### PR TITLE
Use https + checksums for model security

### DIFF
--- a/src/ModelManager.cpp
+++ b/src/ModelManager.cpp
@@ -298,7 +298,7 @@ void ModelManager::fetchRemoteModels() {
     isFetchingRemoteModels_ = true;
     emit fetchingRemoteModels();
 
-    QUrl url("http://data.statmt.org/bergamot/models/models.json");
+    QUrl url(kModelListUrl);
     QNetworkRequest request(url);
     QNetworkReply *reply = network_->get(request);
     connect(reply, &QNetworkReply::finished, this, [=] {

--- a/src/ModelManager.cpp
+++ b/src/ModelManager.cpp
@@ -101,7 +101,8 @@ Model ModelManager::parseModelInfo(QJsonObject& obj, translateLocally::models::L
                                     QString{"modelName"},
                                     QString{"src"},
                                     QString{"trg"},
-                                    QString{"type"}};
+                                    QString{"type"},
+                                    QString{"checksum"}};
     std::vector<QString> keysFLT{QString("version"), QString("API")};
     QString criticalKey = type==Local ? QString("path") : QString("url");
 

--- a/src/ModelManager.h
+++ b/src/ModelManager.h
@@ -25,6 +25,7 @@ struct Model {
     QString src;
     QString trg;
     QString type; // Base or tiny
+    QByteArray checksum;
     float localversion  = -1.0f;
     float localAPI = -1.0f;
     float remoteversion = -1.0f;
@@ -45,6 +46,8 @@ struct Model {
             trg = val;
         } else if (key == "type") {
             type = val;
+        } else if (key == "checksum") {
+            checksum = QByteArray::fromHex(val.toUtf8());
         } else {
             std::cerr << "Unknown key type. " << key.toStdString() << " Something is very wrong!" << std::endl;
         }

--- a/src/ModelManager.h
+++ b/src/ModelManager.h
@@ -7,6 +7,7 @@
 #include "Network.h"
 #include "types.h"
 
+constexpr const char* kModelListUrl = "https://translatelocally.com/models.json";
 
 namespace translateLocally {
     namespace models {

--- a/src/Network.cpp
+++ b/src/Network.cpp
@@ -38,8 +38,10 @@ QNetworkReply* Network::downloadFile(QUrl url, QFile *dest, QCryptographicHash::
     connect(reply, &QIODevice::readyRead, [=] {
         QByteArray buffer = reply->readAll();
 
-        if (dest->write(buffer) == -1)
+        if (dest->write(buffer) == -1) {
             emit error(tr("An error occurred while writing the downloaded data to disk: %1").arg(dest->errorString()));
+            reply->abort();
+        }
 
         hasher->addData(buffer);
     });

--- a/src/Network.h
+++ b/src/Network.h
@@ -2,6 +2,7 @@
 #define NETWORK_H
 #include <QObject>
 #include <QNetworkAccessManager>
+#include <QCryptographicHash>
 #include <memory>
 
 class QFile;
@@ -19,11 +20,11 @@ public:
 
     /**
      * Download a file to a destination on disk. Useful for skipping loading the
-     * file in memory. The `downloadComplete(QFile,QString)` signal will be 
-     * emitted with a pointer to the file and a suggested filename. During 
-     * download the `progressBar(qint64,qint64)` signal will be emitted.
+     * file in memory. Optionally a sha256The `downloadComplete(QFile,QString)` signal will be 
+     * emitted with a pointer to the file and suggested filename.
+     * During download the `progressBar(qint64,qint64)` signal will be emitted.
      */ 
-    QNetworkReply *downloadFile(QUrl url, QFile* dest);
+    QNetworkReply *downloadFile(QUrl url, QFile* dest, QCryptographicHash::Algorithm algorithm = QCryptographicHash::Sha256, QByteArray hash = QByteArray());
 
     /**
      * Overloaded version of `downloadFile(QUrl,QFile)` that downloads to a
@@ -31,7 +32,7 @@ public:
      * `QNetworkReply` object is destroyed. But you can change this by changing
      * the file's parent.
      */
-    QNetworkReply *downloadFile(QUrl url);
+    QNetworkReply *downloadFile(QUrl url, QCryptographicHash::Algorithm algorithm = QCryptographicHash::Sha256, QByteArray hash = QByteArray());
     
 private:
     std::unique_ptr<QNetworkAccessManager> nam_;

--- a/src/Network.h
+++ b/src/Network.h
@@ -20,9 +20,9 @@ public:
 
     /**
      * Download a file to a destination on disk. Useful for skipping loading the
-     * file in memory. Optionally a sha256The `downloadComplete(QFile,QString)` signal will be 
-     * emitted with a pointer to the file and suggested filename.
-     * During download the `progressBar(qint64,qint64)` signal will be emitted.
+     * file in memory. The `downloadComplete(QFile,QString)` signal is emitted
+     * with a pointer to the file and suggested filename. During download the
+     * `progressBar(qint64,qint64)` signal is emitted.
      */ 
     QNetworkReply *downloadFile(QUrl url, QFile* dest, QCryptographicHash::Algorithm algorithm = QCryptographicHash::Sha256, QByteArray hash = QByteArray());
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -305,9 +305,7 @@ void MainWindow::resetTranslator() {
  */
 
 void MainWindow::popupError(QString error) {
-    QMessageBox msgBox(this);
-    msgBox.setText(error);
-    msgBox.exec();
+    QMessageBox::critical(this, tr("An error occurred"), error);
 }
 
 void MainWindow::on_fontAction_triggered() {

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -167,7 +167,7 @@ void MainWindow::downloadModel(Model model) {
     ui_->cancelDownloadButton->setEnabled(true);
     showDownloadPane(true);
 
-    QNetworkReply *reply = network_.downloadFile(model.url);
+    QNetworkReply *reply = network_.downloadFile(model.url, QCryptographicHash::Sha256, model.checksum);
     // If downloadFile could not create a temporary file, abort. network_ will
     // have emitted an error(QString) already so no need to notify.
     if (reply == nullptr) {


### PR DESCRIPTION
- This change switches the model list url to https://translatelocally.com/models.json for the https as per #21.
- Adds a checksum to validate the download, as discussed in #48.

This change adds support for an optional `checksum` property in the model list JSON, which is a hexadecimal sha256 checksum of the file. If this checksum is present, and it does not match that of the downloaded file, the downloaded archive is not extracted and thrown away.

I've used sha256 as that seems to be pretty commonly available. macOS, Windows and Linux ship with command line tools for generating these checksums.