### PR TITLE
Draft: Alignment information

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,6 +110,8 @@ set(PROJECT_SOURCES
         src/Network.h
         src/Settings.cpp
         src/Settings.h
+        src/Translation.h
+        src/Translation.cpp
         src/types.h
         logo/logo_svg.h
         ${TS_FILES}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,6 +97,8 @@ set(PROJECT_SOURCES
         src/mainwindow.cpp
         src/mainwindow.h
         src/mainwindow.ui
+        src/AlignmentHighlighter.cpp
+        src/AlignmentHighlighter.h
         src/TranslatorSettingsDialog.ui
         src/TranslatorSettingsDialog.cpp
         src/TranslatorSettingsDialog.h

--- a/src/AlignmentHighlighter.cpp
+++ b/src/AlignmentHighlighter.cpp
@@ -11,5 +11,28 @@ void AlignmentHighlighter::setWordAlignment(QList<WordAlignment> alignment) {
 }
 
 void AlignmentHighlighter::highlightBlock(QString const &text) {
-	qDebug() << "highlightBlock called with" << text.length() << "chars";
+	std::size_t offset = 0;
+
+	if (previousBlockState() != -1)
+		offset = previousBlockState();
+
+	setCurrentBlockState(offset + text.length());
+
+	for (auto const &word : alignment_) {
+		if (word.end < offset)
+			continue;
+
+		if (word.begin > offset + text.length())
+			break;
+		
+		QColor color(Qt::blue);
+		color.setAlpha(255 * word.prob);
+		
+		QTextCharFormat format;
+		format.setBackground(QBrush(color));
+		
+		setFormat(offset > word.begin ? 0 : word.begin - offset, word.end - word.begin, format);
+	}
+
+	qDebug() << "highlightBlock called with offset" << offset << "and" << text.length() << "chars";
 }

--- a/src/AlignmentHighlighter.cpp
+++ b/src/AlignmentHighlighter.cpp
@@ -1,0 +1,15 @@
+#include "AlignmentHighlighter.h"
+
+AlignmentHighlighter::AlignmentHighlighter(QTextDocument *document)
+: QSyntaxHighlighter(document) {
+	//
+}
+
+void AlignmentHighlighter::setWordAlignment(QList<WordAlignment> alignment) {
+	alignment_ = alignment;
+	rehighlight();
+}
+
+void AlignmentHighlighter::highlightBlock(QString const &text) {
+	qDebug() << "highlightBlock called with" << text.length() << "chars";
+}

--- a/src/AlignmentHighlighter.cpp
+++ b/src/AlignmentHighlighter.cpp
@@ -33,6 +33,4 @@ void AlignmentHighlighter::highlightBlock(QString const &text) {
 		
 		setFormat(offset > word.begin ? 0 : word.begin - offset, word.end - word.begin, format);
 	}
-
-	qDebug() << "highlightBlock called with offset" << offset << "and" << text.length() << "chars";
 }

--- a/src/AlignmentHighlighter.cpp
+++ b/src/AlignmentHighlighter.cpp
@@ -16,7 +16,7 @@ void AlignmentHighlighter::highlightBlock(QString const &text) {
 	if (previousBlockState() != -1)
 		offset = previousBlockState();
 
-	setCurrentBlockState(offset + text.length());
+	setCurrentBlockState(offset + text.length() + 1); // Add 1 for assumed "\n"
 
 	for (auto const &word : alignment_) {
 		if (word.end < offset)
@@ -26,11 +26,12 @@ void AlignmentHighlighter::highlightBlock(QString const &text) {
 			break;
 		
 		QColor color(Qt::blue);
-		color.setAlpha(255 * word.prob);
+		color.setAlphaF(word.prob);
 		
 		QTextCharFormat format;
 		format.setBackground(QBrush(color));
 		
 		setFormat(offset > word.begin ? 0 : word.begin - offset, word.end - word.begin, format);
+		// qDebug() << "from " << (word.begin - offset) << "to" << (word.end - offset) << ": " << word.prob;
 	}
 }

--- a/src/AlignmentHighlighter.cpp
+++ b/src/AlignmentHighlighter.cpp
@@ -26,7 +26,7 @@ void AlignmentHighlighter::highlightBlock(QString const &text) {
 			break;
 		
 		QColor color(Qt::blue);
-		color.setAlphaF(word.prob);
+		color.setAlphaF(.5f * word.prob);
 		
 		QTextCharFormat format;
 		format.setBackground(QBrush(color));

--- a/src/AlignmentHighlighter.h
+++ b/src/AlignmentHighlighter.h
@@ -1,0 +1,20 @@
+#ifndef ALIGNMENTHIGHLIGHTER_H
+#define ALIGNMENTHIGHLIGHTER_H
+#include "MarianInterface.h"
+#include <QList>
+#include <QSyntaxHighlighter>
+#include <QDebug>
+
+class AlignmentHighlighter: public QSyntaxHighlighter {
+	Q_OBJECT
+
+private:
+	QList<WordAlignment> alignment_;
+
+public:
+	AlignmentHighlighter(QTextDocument *document);
+	void setWordAlignment(QList<WordAlignment> alignment);
+	void highlightBlock(QString const &text);
+};
+
+#endif // ALIGNMENTHIGHLIGHTER_H

--- a/src/MarianInterface.cpp
+++ b/src/MarianInterface.cpp
@@ -8,7 +8,6 @@
 #include <thread>
 #include <chrono>
 #include <QMutexLocker>
-#include <QDebug>
 
 namespace  {
 marian::Ptr<marian::Options> MakeOptions(const std::string &path_to_model_dir, translateLocally::marianSettings& settings) {
@@ -62,27 +61,17 @@ bool contains(marian::bergamot::ByteRange const &span, std::size_t pos) {
 }
 
 bool findWordByBytePosition(marian::bergamot::Annotation const &annotation, std::size_t pos, std::size_t &sentenceIdx, std::size_t &wordIdx) {
-    qDebug() << "Here";
-
     for (sentenceIdx = 0; sentenceIdx < annotation.numSentences(); ++sentenceIdx) {
         if (::contains(annotation.sentence(sentenceIdx), pos))
             break;
     }
 
-    qDebug() << "sentenceIdx=" << static_cast<quint64>(sentenceIdx);
-
-    if (sentenceIdx == annotation.numSentences()) {
-        qDebug() << "sentenceIdx == annotation.numSentences()";
+    if (sentenceIdx == annotation.numSentences())
         return false;
-    }
-
+    
     for (wordIdx = 0; wordIdx < annotation.numWords(sentenceIdx); ++wordIdx)
         if (::contains(annotation.word(sentenceIdx, wordIdx), pos))
             break;
-
-    qDebug() << "wordIdx=" << static_cast<quint64>(wordIdx);
-
-    qDebug() << "annotation.numWords(sentenceIdx)=" << annotation.numWords(sentenceIdx);
 
     return wordIdx != annotation.numWords(sentenceIdx);
 }

--- a/src/MarianInterface.cpp
+++ b/src/MarianInterface.cpp
@@ -8,7 +8,6 @@
 #include <thread>
 #include <chrono>
 #include <QMutexLocker>
-#include <QDebug>
 
 namespace  {
 marian::Ptr<marian::Options> MakeOptions(const std::string &path_to_model_dir, translateLocally::marianSettings& settings) {
@@ -49,138 +48,7 @@ int countWords(std::string input) {
     return numWords;
 }
 
-bool contains(marian::bergamot::ByteRange const &span, std::size_t offset) {
-    // return offset >= span.begin && offset < span.end;
-
-    // Note: technically incorrect, but gives better user experience for those
-    // not aware exactly what is happening with sentence piece tokens.
-    return offset > span.begin && offset <= span.end;
-}
-
-bool findWordByByteOffset(marian::bergamot::Annotation const &annotation, std::size_t pos, std::size_t &sentenceIdx, std::size_t &wordIdx) {
-    for (sentenceIdx = 0; sentenceIdx < annotation.numSentences(); ++sentenceIdx) {
-        if (::contains(annotation.sentence(sentenceIdx), pos))
-            break;
-    }
-
-    if (sentenceIdx == annotation.numSentences())
-        return false;
-    
-    for (wordIdx = 0; wordIdx < annotation.numWords(sentenceIdx); ++wordIdx)
-        if (::contains(annotation.word(sentenceIdx, wordIdx), pos))
-            break;
-
-    return wordIdx != annotation.numWords(sentenceIdx);
-}
-
-qsizetype offsetToPosition(std::string const &text, std::size_t offset) {
-    if (offset > text.size()) {
-        qDebug() << "Warning:" << offset << ">" << text.size();
-        return -1;
-    }
-
-    return QString::fromUtf8(text.data(), offset).size();
-}
-
-std::size_t positionToOffset(std::string const &text, qsizetype pos) {
-    return QString::fromStdString(text).left(pos).toLocal8Bit().size();
-}
-
 } // Anonymous namespace
-
-
-
-Translation::Translation()
-: response_()
-, speed_(-1) {
-    //
-}
-
-Translation::Translation(marian::bergamot::Response &&response, int speed)
-: response_(std::make_shared<marian::bergamot::Response>(std::move(response)))
-, speed_(speed) {
-    //
-}
-
-QString Translation::translation() const {
-    return QString::fromStdString(response_->target.text);
-}
-
-QList<WordAlignment> Translation::alignments(qsizetype sourcePosFirst, qsizetype sourcePosLast) const {
-    QList<WordAlignment> alignments;
-    std::size_t sentenceIdxFirst, sentenceIdxLast, wordIdxFirst, wordIdxLast;
-
-    if (!response_)
-        return alignments;
-
-    if (sourcePosFirst > sourcePosLast)
-        std::swap(sourcePosFirst, sourcePosLast);
-
-    std::size_t sourceOffsetFirst = ::positionToOffset(response_->source.text, sourcePosFirst);
-
-    if (!findWordByByteOffset(response_->source.annotation, sourceOffsetFirst, sentenceIdxFirst, wordIdxFirst))
-        return alignments;
-
-    std::size_t sourceOffsetLast = ::positionToOffset(response_->source.text, sourcePosLast);
-
-    if (!findWordByByteOffset(response_->source.annotation, sourceOffsetLast, sentenceIdxLast, wordIdxLast))
-        return alignments;
-
-    qDebug() << "From" <<sourcePosFirst << "to" << sourcePosLast << "==" << sentenceIdxFirst << ":" << wordIdxFirst << "to" << sentenceIdxLast << ":" << wordIdxLast;
-
-    assert(sentenceIdxFirst <= sentenceIdxLast);
-    assert(sentenceIdxFirst != sentenceIdxLast || wordIdxFirst <= wordIdxLast);
-    assert(sentenceIdxLast < response_->alignments.size());
-
-    for (std::size_t sentenceIdx = sentenceIdxFirst; sentenceIdx <= sentenceIdxLast; ++sentenceIdx) {
-        assert(sentenceIdx < response_->alignments.size());
-        std::size_t firstWord = sentenceIdx == sentenceIdxFirst ? wordIdxFirst : 0;
-        std::size_t lastWord = sentenceIdx == sentenceIdxLast ? wordIdxLast : response_->source.numWords(sentenceIdx) - 1;
-        for (marian::bergamot::Point const &point : response_->alignments[sentenceIdx]) {
-            if (point.src >= firstWord && point.src <= lastWord) {
-                auto span = response_->target.wordAsByteRange(sentenceIdx, point.tgt);
-                WordAlignment alignment;
-                alignment.begin = ::offsetToPosition(response_->target.text, span.begin);
-                alignment.end = ::offsetToPosition(response_->target.text, span.end);
-                alignment.prob = point.prob;
-                alignments.append(alignment);
-            }
-        }
-    }
-
-    return alignments;
-}
-
-qsizetype Translation::findSourcePosition(qsizetype targetPos) const {
-    std::size_t sentenceIdx, wordIdx;
-
-    if (!response_)
-        return -1;
-
-    std::size_t targetOffset = ::positionToOffset(response_->target.text, targetPos);
-
-    if (!findWordByByteOffset(response_->target.annotation, targetOffset, sentenceIdx, wordIdx))
-        return -1;
-
-    auto word = response_->target.word(sentenceIdx, wordIdx);
-    // qDebug() << "Found position" << targetPos << "in word" << QString::fromUtf8(word.data(), word.size());
-
-    marian::bergamot::Point best;
-    best.prob = -1.0f;
-
-    assert(sentenceIdx < response_->alignments.size());
-    for (marian::bergamot::Point const &point : response_->alignments[sentenceIdx])
-        if (point.tgt == wordIdx && point.prob > best.prob)
-            best = point;
-
-    if (best.prob < 0.0)
-        return -1;
-
-    auto sourceOffset = response_->source.wordAsByteRange(sentenceIdx, best.src).begin;
-    // qDebug() << "Found opposite word at " << sourceOffset << "with word" << QString::fromUtf8(response_->source.word(sentenceIdx, best.src));
-
-    return ::offsetToPosition(response_->source.text, sourceOffset);
-}
 
 struct ModelDescription {
     std::string config_file;

--- a/src/MarianInterface.cpp
+++ b/src/MarianInterface.cpp
@@ -50,7 +50,11 @@ int countWords(std::string input) {
 }
 
 bool contains(marian::bergamot::ByteRange const &span, std::size_t offset) {
-    return offset >= span.begin && offset < span.end;
+    // return offset >= span.begin && offset < span.end;
+
+    // Note: technically incorrect, but gives better user experience for those
+    // not aware exactly what is happening with sentence piece tokens.
+    return offset > span.begin && offset <= span.end;
 }
 
 bool findWordByByteOffset(marian::bergamot::Annotation const &annotation, std::size_t pos, std::size_t &sentenceIdx, std::size_t &wordIdx) {

--- a/src/MarianInterface.cpp
+++ b/src/MarianInterface.cpp
@@ -49,11 +49,7 @@ int countWords(std::string input) {
 }
 
 WordAlignment MakeWordAlignment(marian::bergamot::ByteRange const &span, float prob) {
-    return WordAlignment{
-        .begin=span.begin,
-        .end=span.end,
-        .prob=prob
-    };
+    return WordAlignment(span.begin, span.end, prob);
 }
 
 bool contains(marian::bergamot::ByteRange const &span, std::size_t pos) {
@@ -182,15 +178,13 @@ MarianInterface::MarianInterface(QObject *parent)
                 } else if (input) {
                     if (service) {
                         auto start = std::chrono::steady_clock::now(); // Time the translation
-                        std::future<int> num_words = std::async (countWords,*input); // @TODO we're doing an unnecessary string copy here
-                        std::future<marian::bergamot::Response> responseFuture = service->translate(
-                            std::move(*input),
-                            marian::bergamot::ResponseOptions{
-                                .qualityScores=true,
-                                .alignment=true,
-                                .alignmentThreshold=0.2f
-                            }
-                        );
+                        std::future<int> num_words = std::async(countWords, *input); // @TODO we're doing an unnecessary string copy here
+
+                        marian::bergamot::ResponseOptions options;
+                        options.alignment = true;
+                        options.alignmentThreshold = 0.2f;
+
+                        std::future<marian::bergamot::Response> responseFuture = service->translate(std::move(*input), options);
                         responseFuture.wait();
                         auto end = std::chrono::steady_clock::now();
                         // Calculate translation speed in terms of words per second

--- a/src/MarianInterface.cpp
+++ b/src/MarianInterface.cpp
@@ -140,14 +140,12 @@ MarianInterface::MarianInterface(QObject *parent)
                             }
                         );
                         responseFuture.wait();
-                        marian::bergamot::Response response = responseFuture.get();
-                        num_words.wait();
                         auto end = std::chrono::steady_clock::now();
                         // Calculate translation speed in terms of words per second
                         double words = num_words.get();
                         std::chrono::duration<double> elapsed_seconds = end-start;
                         int translationSpeed = std::ceil(words/elapsed_seconds.count()); // @TODO this could probably be done in the service in the future
-                        emit translationReady(Translation(std::move(response), translationSpeed));
+                        emit translationReady(Translation(std::move(responseFuture.get()), translationSpeed));
                     } else {
                         // TODO: What? Raise error? Set model_ to ""?
                     }

--- a/src/MarianInterface.h
+++ b/src/MarianInterface.h
@@ -51,7 +51,7 @@ public:
      * aligning with the word at char pos `pos` in the source sentence. Returns
      * an empty list on failure.
      */
-    QList<WordAlignment> alignments(qsizetype pos) const;
+    QList<WordAlignment> alignments(qsizetype begin, qsizetype end) const;
 
     /**
      * Looks up the best cursor position for a source word when the position

--- a/src/MarianInterface.h
+++ b/src/MarianInterface.h
@@ -23,6 +23,13 @@ struct WordAlignment {
     std::size_t begin;
     std::size_t end;
     float prob;
+
+    inline WordAlignment(std::size_t begin, std::size_t end, float prob)
+    : begin(begin)
+    , end(end)
+    , prob(prob) {
+        //
+    }
 };
 
 class Translation {

--- a/src/MarianInterface.h
+++ b/src/MarianInterface.h
@@ -48,8 +48,21 @@ public:
         return !!response_;
     }
 
+    inline std::size_t wordsPerSecond() const {
+        return speed_;
+    }
+
+    /**
+     * Translation result
+     */
     QString translation() const;
-    QList<WordAlignment> alignments(std::size_t pos) const;
+
+    /**
+     * Looks up a list of character ranges and probability scores for words
+     * aligning with the word at char pos `pos` in the source sentence. Returns
+     * an empty list on failure.
+     */
+    QList<WordAlignment> alignments(qsizetype pos) const;
 };
 
 Q_DECLARE_METATYPE(Translation)

--- a/src/MarianInterface.h
+++ b/src/MarianInterface.h
@@ -1,6 +1,7 @@
 #ifndef MARIANINTERFACE_H
 #define MARIANINTERFACE_H
 #include <QString>
+#include <QList>
 #include <QObject>
 #include <QMutex>
 #include <QSemaphore>
@@ -18,18 +19,30 @@ namespace marian {
 
 struct ModelDescription;
 
+struct WordAlignment {
+    std::size_t begin;
+    std::size_t end;
+    float prob;
+};
+
 class Translation {
 private:
     std::shared_ptr<marian::bergamot::Response> response_;
     int speed_;
 public:
+    Translation();
     Translation(marian::bergamot::Response &&response, int speed);
 
     inline std::size_t wordsPerSecond() const {
         return speed_;
     }
 
+    inline operator bool() const {
+        return !!response_;
+    }
+
     QString translation() const;
+    QList<WordAlignment> alignments(std::size_t pos) const;
 };
 
 Q_DECLARE_METATYPE(Translation)

--- a/src/MarianInterface.h
+++ b/src/MarianInterface.h
@@ -6,6 +6,7 @@
 #include <QMutex>
 #include <QSemaphore>
 #include "types.h"
+#include "Translation.h"
 #include <thread>
 #include <memory>
 
@@ -13,54 +14,10 @@
 namespace marian {
     namespace bergamot {
     class Service;
-    class Response;
     }
 }
 
 struct ModelDescription;
-
-struct WordAlignment {
-    std::size_t begin;
-    std::size_t end;
-    float prob;
-};
-
-class Translation {
-private:
-    std::shared_ptr<marian::bergamot::Response> response_;
-    int speed_;
-public:
-    Translation();
-    Translation(marian::bergamot::Response &&response, int speed);
-
-    inline operator bool() const {
-        return !!response_;
-    }
-
-    inline std::size_t wordsPerSecond() const {
-        return speed_;
-    }
-
-    /**
-     * Translation result
-     */
-    QString translation() const;
-
-    /**
-     * Looks up a list of character ranges and probability scores for words
-     * aligning with the word at char pos `pos` in the source sentence. Returns
-     * an empty list on failure.
-     */
-    QList<WordAlignment> alignments(qsizetype begin, qsizetype end) const;
-
-    /**
-     * Looks up the best cursor position for a source word when the position
-     * of a target word is given. Returns -1 on failure.
-     */
-    qsizetype findSourcePosition(qsizetype pos) const;
-};
-
-Q_DECLARE_METATYPE(Translation)
 
 class MarianInterface : public QObject {
     Q_OBJECT

--- a/src/MarianInterface.h
+++ b/src/MarianInterface.h
@@ -23,13 +23,6 @@ struct WordAlignment {
     std::size_t begin;
     std::size_t end;
     float prob;
-
-    inline WordAlignment(std::size_t begin, std::size_t end, float prob)
-    : begin(begin)
-    , end(end)
-    , prob(prob) {
-        //
-    }
 };
 
 class Translation {
@@ -39,10 +32,6 @@ private:
 public:
     Translation();
     Translation(marian::bergamot::Response &&response, int speed);
-
-    inline std::size_t wordsPerSecond() const {
-        return speed_;
-    }
 
     inline operator bool() const {
         return !!response_;
@@ -63,6 +52,12 @@ public:
      * an empty list on failure.
      */
     QList<WordAlignment> alignments(qsizetype pos) const;
+
+    /**
+     * Looks up the best cursor position for a source word when the position
+     * of a target word is given. Returns -1 on failure.
+     */
+    qsizetype findSourcePosition(qsizetype pos) const;
 };
 
 Q_DECLARE_METATYPE(Translation)

--- a/src/MarianInterface.h
+++ b/src/MarianInterface.h
@@ -12,10 +12,27 @@
 namespace marian {
     namespace bergamot {
     class Service;
+    class Response;
     }
 }
 
 struct ModelDescription;
+
+class Translation {
+private:
+    std::shared_ptr<marian::bergamot::Response> response_;
+    int speed_;
+public:
+    Translation(marian::bergamot::Response &&response, int speed);
+
+    inline std::size_t wordsPerSecond() const {
+        return speed_;
+    }
+
+    QString translation() const;
+};
+
+Q_DECLARE_METATYPE(Translation)
 
 class MarianInterface : public QObject {
     Q_OBJECT
@@ -35,7 +52,7 @@ public:
     void setModel(QString path_to_model_dir, const translateLocally::marianSettings& settings);
     void translate(QString in);
 signals:
-    void translationReady(QString translation, int);
+    void translationReady(Translation translation);
     void pendingChanged(bool isBusy);
     void error(QString message);
 };

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -13,6 +13,7 @@ Settings::Settings(QObject *parent)
 , cores(backing_, "cpu_cores", std::thread::hardware_concurrency())
 , workspace(backing_, "workspace", 128)
 , splitOrientation(backing_, "split", Qt::Vertical)
+, showAlignment(backing_, "show_alignment", false)
 , windowGeometry(backing_, "window_geometry") {
     //
 }

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -88,5 +88,6 @@ public:
     SettingImpl<unsigned int> cores;
     SettingImpl<unsigned int> workspace;
     SettingImpl<Qt::Orientation> splitOrientation;
+    SettingImpl<bool> showAlignment;
     SettingImpl<QByteArray> windowGeometry;
 };

--- a/src/Translation.cpp
+++ b/src/Translation.cpp
@@ -28,14 +28,14 @@ bool findWordByByteOffset(marian::bergamot::Annotation const &annotation, std::s
     return wordIdx != annotation.numWords(sentenceIdx);
 }
 
-qsizetype offsetToPosition(std::string const &text, std::size_t offset) {
+int offsetToPosition(std::string const &text, std::size_t offset) {
     if (offset > text.size())
         return -1;
 
     return QString::fromUtf8(text.data(), offset).size();
 }
 
-std::size_t positionToOffset(std::string const &text, qsizetype pos) {
+std::size_t positionToOffset(std::string const &text, int pos) {
     return QString::fromStdString(text).left(pos).toLocal8Bit().size();
 }
 
@@ -57,7 +57,7 @@ QString Translation::translation() const {
     return QString::fromStdString(response_->target.text);
 }
 
-QList<WordAlignment> Translation::alignments(qsizetype sourcePosFirst, qsizetype sourcePosLast) const {
+QList<WordAlignment> Translation::alignments(int sourcePosFirst, int sourcePosLast) const {
     QList<WordAlignment> alignments;
     std::size_t sentenceIdxFirst, sentenceIdxLast, wordIdxFirst, wordIdxLast;
 
@@ -102,7 +102,7 @@ QList<WordAlignment> Translation::alignments(qsizetype sourcePosFirst, qsizetype
     return alignments;
 }
 
-qsizetype Translation::findSourcePosition(qsizetype targetPos) const {
+int Translation::findSourcePosition(int targetPos) const {
     std::size_t sentenceIdx, wordIdx;
 
     if (!response_)

--- a/src/Translation.cpp
+++ b/src/Translation.cpp
@@ -1,0 +1,134 @@
+#include "Translation.h"
+#include "3rd_party/bergamot-translator/src/translator/response.h"
+#include <QDebug>
+
+namespace {
+
+bool contains(marian::bergamot::ByteRange const &span, std::size_t offset) {
+    // return offset >= span.begin && offset < span.end;
+
+    // Note: technically incorrect, but gives better user experience for those
+    // not aware exactly what is happening with sentence piece tokens.
+    return offset > span.begin && offset <= span.end;
+}
+
+bool findWordByByteOffset(marian::bergamot::Annotation const &annotation, std::size_t pos, std::size_t &sentenceIdx, std::size_t &wordIdx) {
+    for (sentenceIdx = 0; sentenceIdx < annotation.numSentences(); ++sentenceIdx) {
+        if (::contains(annotation.sentence(sentenceIdx), pos))
+            break;
+    }
+
+    if (sentenceIdx == annotation.numSentences())
+        return false;
+    
+    for (wordIdx = 0; wordIdx < annotation.numWords(sentenceIdx); ++wordIdx)
+        if (::contains(annotation.word(sentenceIdx, wordIdx), pos))
+            break;
+
+    return wordIdx != annotation.numWords(sentenceIdx);
+}
+
+qsizetype offsetToPosition(std::string const &text, std::size_t offset) {
+    if (offset > text.size())
+        return -1;
+
+    return QString::fromUtf8(text.data(), offset).size();
+}
+
+std::size_t positionToOffset(std::string const &text, qsizetype pos) {
+    return QString::fromStdString(text).left(pos).toLocal8Bit().size();
+}
+
+} // Anonymous namespace
+
+Translation::Translation()
+: response_()
+, speed_(-1) {
+    //
+}
+
+Translation::Translation(marian::bergamot::Response &&response, int speed)
+: response_(std::make_shared<marian::bergamot::Response>(std::move(response)))
+, speed_(speed) {
+    //
+}
+
+QString Translation::translation() const {
+    return QString::fromStdString(response_->target.text);
+}
+
+QList<WordAlignment> Translation::alignments(qsizetype sourcePosFirst, qsizetype sourcePosLast) const {
+    QList<WordAlignment> alignments;
+    std::size_t sentenceIdxFirst, sentenceIdxLast, wordIdxFirst, wordIdxLast;
+
+    if (!response_)
+        return alignments;
+
+    if (sourcePosFirst > sourcePosLast)
+        std::swap(sourcePosFirst, sourcePosLast);
+
+    std::size_t sourceOffsetFirst = ::positionToOffset(response_->source.text, sourcePosFirst);
+
+    if (!findWordByByteOffset(response_->source.annotation, sourceOffsetFirst, sentenceIdxFirst, wordIdxFirst))
+        return alignments;
+
+    std::size_t sourceOffsetLast = ::positionToOffset(response_->source.text, sourcePosLast);
+
+    if (!findWordByByteOffset(response_->source.annotation, sourceOffsetLast, sentenceIdxLast, wordIdxLast))
+        return alignments;
+
+    // qDebug() << "From" <<sourcePosFirst << "to" << sourcePosLast << "==" << sentenceIdxFirst << ":" << wordIdxFirst << "to" << sentenceIdxLast << ":" << wordIdxLast;
+
+    assert(sentenceIdxFirst <= sentenceIdxLast);
+    assert(sentenceIdxFirst != sentenceIdxLast || wordIdxFirst <= wordIdxLast);
+    assert(sentenceIdxLast < response_->alignments.size());
+
+    for (std::size_t sentenceIdx = sentenceIdxFirst; sentenceIdx <= sentenceIdxLast; ++sentenceIdx) {
+        assert(sentenceIdx < response_->alignments.size());
+        std::size_t firstWord = sentenceIdx == sentenceIdxFirst ? wordIdxFirst : 0;
+        std::size_t lastWord = sentenceIdx == sentenceIdxLast ? wordIdxLast : response_->source.numWords(sentenceIdx) - 1;
+        for (marian::bergamot::Point const &point : response_->alignments[sentenceIdx]) {
+            if (point.src >= firstWord && point.src <= lastWord) {
+                auto span = response_->target.wordAsByteRange(sentenceIdx, point.tgt);
+                WordAlignment alignment;
+                alignment.begin = ::offsetToPosition(response_->target.text, span.begin);
+                alignment.end = ::offsetToPosition(response_->target.text, span.end);
+                alignment.prob = point.prob;
+                alignments.append(alignment);
+            }
+        }
+    }
+
+    return alignments;
+}
+
+qsizetype Translation::findSourcePosition(qsizetype targetPos) const {
+    std::size_t sentenceIdx, wordIdx;
+
+    if (!response_)
+        return -1;
+
+    std::size_t targetOffset = ::positionToOffset(response_->target.text, targetPos);
+
+    if (!findWordByByteOffset(response_->target.annotation, targetOffset, sentenceIdx, wordIdx))
+        return -1;
+
+    auto word = response_->target.word(sentenceIdx, wordIdx);
+    // qDebug() << "Found position" << targetPos << "in word" << QString::fromUtf8(word.data(), word.size());
+
+    marian::bergamot::Point best;
+    best.prob = -1.0f;
+
+    assert(sentenceIdx < response_->alignments.size());
+    for (marian::bergamot::Point const &point : response_->alignments[sentenceIdx])
+        if (point.tgt == wordIdx && point.prob > best.prob)
+            best = point;
+
+    if (best.prob < 0.0)
+        return -1;
+
+    auto sourceOffset = response_->source.wordAsByteRange(sentenceIdx, best.src).begin;
+    // qDebug() << "Found opposite word at " << sourceOffset << "with word" << QString::fromUtf8(response_->source.word(sentenceIdx, best.src));
+
+    return ::offsetToPosition(response_->source.text, sourceOffset);
+}

--- a/src/Translation.h
+++ b/src/Translation.h
@@ -1,0 +1,56 @@
+#ifndef TRANSLATION_H
+#define TRANSLATION_H
+#include <QMetaType>
+#include <QString>
+#include <memory>
+
+namespace marian {
+    namespace bergamot {
+        class Response;
+    }
+}
+
+struct WordAlignment {
+    std::size_t begin;
+    std::size_t end;
+    float prob;
+};
+
+class Translation {
+private:
+    std::shared_ptr<marian::bergamot::Response> response_;
+    int speed_;
+public:
+    Translation();
+    Translation(marian::bergamot::Response &&response, int speed);
+
+    inline operator bool() const {
+        return !!response_;
+    }
+
+    inline std::size_t wordsPerSecond() const {
+        return speed_;
+    }
+
+    /**
+     * Translation result
+     */
+    QString translation() const;
+
+    /**
+     * Looks up a list of character ranges and probability scores for words
+     * aligning with the word at char pos `pos` in the source sentence. Returns
+     * an empty list on failure.
+     */
+    QList<WordAlignment> alignments(qsizetype begin, qsizetype end) const;
+
+    /**
+     * Looks up the best cursor position for a source word when the position
+     * of a target word is given. Returns -1 on failure.
+     */
+    qsizetype findSourcePosition(qsizetype pos) const;
+};
+
+Q_DECLARE_METATYPE(Translation)
+
+#endif // TRANSLATION_H

--- a/src/Translation.h
+++ b/src/Translation.h
@@ -10,20 +10,37 @@ namespace marian {
     }
 }
 
+/**
+ * Word alignment information, with information about a span in the translation
+ * output as answer to querying which parts 'belong' to a span in the
+ * translation input.
+ */
 struct WordAlignment {
-    std::size_t begin;
+    std::size_t begin; // Note: char offset in translation (not byte offset)
     std::size_t end;
-    float prob;
+    float prob; // Range: 0.0 - 1.0
 };
 
+/**
+ * Wrapper around a translation response from the bergamot service. Hides that
+ * interface from the rest of the Qt code, and provides utility functions to
+ * access alignment information with character offsets instead of byte offsets.
+ */
 class Translation {
 private:
+    // Note: I would have liked unique_ptr, but that does not go well with
+    // passing Translation objects through Qt signals/slots.
     std::shared_ptr<marian::bergamot::Response> response_;
+
     int speed_;
 public:
     Translation();
     Translation(marian::bergamot::Response &&response, int speed);
 
+    /**
+     * Bool operator to check whether this is an initialised translation or just
+     * an empty object.
+     */
     inline operator bool() const {
         return !!response_;
     }

--- a/src/Translation.h
+++ b/src/Translation.h
@@ -42,13 +42,13 @@ public:
      * aligning with the word at char pos `pos` in the source sentence. Returns
      * an empty list on failure.
      */
-    QList<WordAlignment> alignments(qsizetype begin, qsizetype end) const;
+    QList<WordAlignment> alignments(int begin, int end) const;
 
     /**
      * Looks up the best cursor position for a source word when the position
      * of a target word is given. Returns -1 on failure.
      */
-    qsizetype findSourcePosition(qsizetype pos) const;
+    int findSourcePosition(int pos) const;
 };
 
 Q_DECLARE_METATYPE(Translation)

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -365,3 +365,19 @@ void MainWindow::on_inputBox_cursorPositionChanged() {
     auto alignments = translation_.alignments(ui_->inputBox->textCursor().position());
     highlighter_->setWordAlignment(alignments);
 }
+
+void MainWindow::on_outputBox_cursorPositionChanged() {
+    if (!translation_)
+        return;
+
+    int outputPosition = ui_->outputBox->textCursor().position();
+    
+    int sourcePosition = translation_.findSourcePosition(outputPosition);
+    
+    if (sourcePosition < 0)
+        return;
+    
+    QTextCursor cursor(ui_->inputBox->textCursor());
+    cursor.setPosition(sourcePosition);
+    ui_->inputBox->setTextCursor(cursor);
+}

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -362,6 +362,8 @@ void MainWindow::on_inputBox_cursorPositionChanged() {
     if (!translation_ || !highlighter_)
         return;
 
+    // Highlight words in the translation box that match the words currently
+    // selected in the input box.
     auto cursor = ui_->inputBox->textCursor();
     auto alignments = translation_.alignments(cursor.position(), cursor.anchor());
     highlighter_->setWordAlignment(alignments);
@@ -371,13 +373,17 @@ void MainWindow::on_outputBox_cursorPositionChanged() {
     if (!translation_)
         return;
 
+    // Find which word (and its character position) is most relevant for the
+    // word under the cursor in the translation I just clicked on.
     int outputPosition = ui_->outputBox->textCursor().position();
-    
     int sourcePosition = translation_.findSourcePosition(outputPosition);
     
     if (sourcePosition < 0)
         return;
     
+    // Move cursor in input box to that position.
+    // TODO: maybe also move focus to this box so you can see the cursor? Might
+    // interfere with copy/paste interaction though.
     QTextCursor cursor(ui_->inputBox->textCursor());
     cursor.setPosition(sourcePosition);
     ui_->inputBox->setTextCursor(cursor);

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -362,7 +362,8 @@ void MainWindow::on_inputBox_cursorPositionChanged() {
     if (!translation_ || !highlighter_)
         return;
 
-    auto alignments = translation_.alignments(ui_->inputBox->textCursor().position());
+    auto cursor = ui_->inputBox->textCursor();
+    auto alignments = translation_.alignments(cursor.position(), cursor.anchor());
     highlighter_->setWordAlignment(alignments);
 }
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -98,6 +98,8 @@ MainWindow::MainWindow(QWidget *parent)
     connect(translator_.get(), &MarianInterface::error, this, &MainWindow::popupError);
     connect(translator_.get(), &MarianInterface::translationReady, this, [&](Translation translation) {
         ui_->outputBox->setText(translation.translation());
+        auto highlighter = new AlignmentHighlighter(ui_->outputBox->document());
+
         ui_->translateAction->setEnabled(true); // Re-enable button after translation is done
         ui_->translateButton->setEnabled(true);
         if (translation.wordsPerSecond() > 0) { // Display the translation speed only if it's > 0. This prevents the user seeing weird number if pressed translate with empty input
@@ -342,4 +344,8 @@ void MainWindow::on_actionSplit_Horizontally_triggered() {
 
 void MainWindow::on_actionSplit_Vertically_triggered() {
     settings_.splitOrientation.setValue(Qt::Vertical);
+}
+
+void MainWindow::on_outputBox_cursorPositionChanged() {
+    // translator_->queryAlignment(ui_->outputBox->textCursor().position());
 }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -96,12 +96,12 @@ MainWindow::MainWindow(QWidget *parent)
     // Set up the connection to the translator
     connect(translator_.get(), &MarianInterface::pendingChanged, ui_->pendingIndicator, &QProgressBar::setVisible);
     connect(translator_.get(), &MarianInterface::error, this, &MainWindow::popupError);
-    connect(translator_.get(), &MarianInterface::translationReady, this, [&](QString translation, int speed) {
-        ui_->outputBox->setText(translation);
+    connect(translator_.get(), &MarianInterface::translationReady, this, [&](Translation translation) {
+        ui_->outputBox->setText(translation.translation());
         ui_->translateAction->setEnabled(true); // Re-enable button after translation is done
         ui_->translateButton->setEnabled(true);
-        if (speed > 0) { // Display the translation speed only if it's > 0. This prevents the user seeing weird number if pressed translate with empty input
-            ui_->statusbar->showMessage(tr("Translation speed: %1 words per second.").arg(speed));
+        if (translation.wordsPerSecond() > 0) { // Display the translation speed only if it's > 0. This prevents the user seeing weird number if pressed translate with empty input
+            ui_->statusbar->showMessage(tr("Translation speed: %1 words per second.").arg(translation.wordsPerSecond()));
         } else {
             ui_->statusbar->clearMessage();
         }

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -41,6 +41,8 @@ private slots:
 
     void on_inputBox_cursorPositionChanged();
 
+    void on_outputBox_cursorPositionChanged();
+
     void on_translateAction_triggered();
 
     void on_translateButton_clicked();

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -3,6 +3,7 @@
 #include <QMainWindow>
 #include <QJsonObject>
 #include <memory>
+#include "AlignmentHighlighter.h"
 #include "Network.h"
 #include "ModelManager.h"
 #include "TranslatorSettingsDialog.h"
@@ -37,6 +38,8 @@ public slots:
 
 private slots:
     void on_inputBox_textChanged();
+
+    void on_outputBox_cursorPositionChanged();
 
     void on_translateAction_triggered();
 

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -39,7 +39,7 @@ public slots:
 private slots:
     void on_inputBox_textChanged();
 
-    void on_outputBox_cursorPositionChanged();
+    void on_inputBox_cursorPositionChanged();
 
     void on_translateAction_triggered();
 
@@ -67,8 +67,13 @@ private slots:
 
 private:
     Ui::MainWindow * ui_; // Sadly QTCreator can't do its job if Ui::MainWindow is wrapped inside a smart ptr, so raw pointer it is
+    AlignmentHighlighter *highlighter_; // Owned by ui_->outputBox
+                                        // @TODO: risky pointer to possibly freed object!
+
     // Translator related settings
     std::unique_ptr<MarianInterface> translator_;
+    Translation translation_;
+
     void resetTranslator();
     void showDownloadPane(bool visible);
     void downloadModel(Model model);

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -67,8 +67,7 @@ private slots:
 
 private:
     Ui::MainWindow * ui_; // Sadly QTCreator can't do its job if Ui::MainWindow is wrapped inside a smart ptr, so raw pointer it is
-    AlignmentHighlighter *highlighter_; // Owned by ui_->outputBox
-                                        // @TODO: risky pointer to possibly freed object!
+    std::unique_ptr<AlignmentHighlighter> highlighter_;
 
     // Translator related settings
     std::unique_ptr<MarianInterface> translator_;

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -203,6 +203,8 @@
     </property>
     <addaction name="actionSplit_Horizontally"/>
     <addaction name="actionSplit_Vertically"/>
+    <addaction name="separator"/>
+    <addaction name="actionShowAlignment"/>
    </widget>
    <addaction name="menuEdit"/>
    <addaction name="menuView"/>
@@ -258,6 +260,14 @@
    <property name="shortcut">
     <string>Ctrl+2</string>
    </property>
+  </action>
+  <action name="actionShowAlignment">
+    <property name="checkable">
+      <bool>true</bool>
+    </property>
+    <property name="text">
+      <string>Show Alignment</string>
+    </property>
   </action>
  </widget>
  <resources/>

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -60,6 +60,9 @@
           <property name="placeholderText">
            <string>Enter text to be translated here...</string>
           </property>
+          <property name="tabChangesFocus">
+            <bool>true</bool>
+          </property>
          </widget>
          <widget class="QTextBrowser" name="outputBox"/>
         </widget>


### PR DESCRIPTION
Implementation of #50

This pull requests adds a QSyntaxHighlighter to the translation output box that highlights the alignment probability of words (or sentencepiece tokens really) in the output box given the sentencepiece token currently under the cursor in the input box.

There's a toggle to turn it on/off in the *View* menu.

It also works when you select more than one word in the input box. It will then highlight all the parts that match that selection. The probability-based colour will make less sense in that case though.

Additionally, if you click on a word in the output box (the translation) it will move the cursor in the input box with the word that aligns best with it. However, it does not move the focus to the input box, so the only way to then use that moved cursor is through tapping [shift] + [tab]. I'm not yet sure about the usefulness of this feature.

<img width="565" alt="image" src="https://user-images.githubusercontent.com/198639/135597250-3b2bf886-354c-4d19-8be8-d9c4cdd00e66.png">

