### PR TITLE
Add an initial command line interface

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,6 +118,9 @@ set(PROJECT_SOURCES
         src/Translation.h
         src/Translation.cpp
         src/types.h
+        src/CommandLineIface.h
+        src/CommandLineIface.cpp
+        src/CLIParsing.h
         logo/logo_svg.h
         ${TS_FILES}
 )

--- a/README.md
+++ b/README.md
@@ -10,7 +10,55 @@ make -j5
 ./translateLocally
 ```
 
-Requires `QT>=5 libarchive`. We make use of the `QT>=5 network`, `QT>=5 linguisticTool` and `QT>=5 svg` components. Depending on your distro, those may be split in separate package from your QT package (Eg `qt{6/7}-tools-dev`; `qt{5/6}-svg` or `libqt5svg5-dev`). QT6 is fully supported and its use is encouraged.
+Requires `QT>=5 libarchive intel-mkl-static`. We make use of the `QT>=5 network`, `QT>=5 linguisticTool` and `QT>=5 svg` components. Depending on your distro, those may be split in separate package from your QT package (Eg `qt{6/7}-tools-dev`; `qt{5/6}-svg` or `libqt5svg5-dev`). QT6 is fully supported and its use is encouraged. `intel-mkl-static` may be part of `mkl` or `intel-mkl` packages.
+
+## Command line interface
+translateLocally supports using the command line to perform translations. Example usage:
+```bash
+./translateLocally --help
+Usage: ./translateLocally [options]
+A secure translation service that performs translations for you locally, on your own machine.
+
+Options:
+  -h, --help             Displays help on commandline options.
+  --help-all             Displays help including Qt specific options.
+  -v, --version          Displays version information.
+  -l, --list-models      List available models.
+  -m, --model <model>    Select model for translation.
+  -i, --input <input>    Source translation text (or just used stdin).
+  -o, --output <output>  Target translation output (or just used stdout).
+```
+
+### Listing available models
+The user needs to download the model and customise the translator settings from the GUI. Then, the avialble models can be listed with `-l`
+```
+./translateLocally -l
+Czech-English type: tiny version: 1; To invoke do -m cs-en-tiny
+German-English type: tiny version: 2; To invoke do -m de-en-tiny
+English-Czech type: tiny version: 1; To invoke do -m en-cs-tiny
+English-German type: tiny version: 2; To invoke do -m en-de-tiny
+English-Spanish type: tiny version: 1; To invoke do -m en-es-tiny
+Spanish-English type: tiny version: 1; To invoke do -m es-en-tiny
+```
+
+### Translating a single sentence
+```
+echo "Me gustaria comprar la casa verde" | ./translateLocally -m es-en-tiny
+```
+
+### Translating a whole dataset
+```
+sacrebleu -t wmt13 -l en-es --echo ref > /tmp/es.in
+./translateLocally -m es-en-tiny -i /tmp/es.in -o /tmp/en.out
+```
+
+### Pivoting and piping
+The command line interface can be used to chain several translation models to achieve pivot translation, for example Spanish to German.
+```
+sacrebleu -t wmt13 -l en-es --echo ref > /tmp/es.in
+cat /tmp/es.in | ./translateLocally -m es-en-tiny | ./translateLocally -m en-de-tiny -o /tmp/de.out
+```
+
 
 # Acnowledgements
 <img src="https://raw.githubusercontent.com/XapaJIaMnu/translateLocally/master/eu-logo.png" data-canonical-src="https://raw.githubusercontent.com/XapaJIaMnu/translateLocally/master/eu-logo.png" width=10% />

--- a/src/CLIParsing.h
+++ b/src/CLIParsing.h
@@ -16,8 +16,8 @@ static void CLIArgumentInit(QApplication& translateLocallyApp, QCommandLineParse
     parser.addVersionOption();
     parser.addOption({{"l", "list-models"}, QObject::tr("List available models.")});
     parser.addOption({{"m", "model"}, QObject::tr("Select model for translation."), "model", ""});
-    parser.addOption({{"i", "input"}, QObject::tr("Source translation text (or just used stdin)"), "input", ""});
-    parser.addOption({{"o", "output"}, QObject::tr("Target translation output (or just used stdout)"), "output", ""});
+    parser.addOption({{"i", "input"}, QObject::tr("Source translation text (or just used stdin)."), "input", ""});
+    parser.addOption({{"o", "output"}, QObject::tr("Target translation output (or just used stdout)."), "output", ""});
     parser.process(translateLocallyApp);
 }
 

--- a/src/CLIParsing.h
+++ b/src/CLIParsing.h
@@ -1,0 +1,42 @@
+#pragma once
+#include <QApplication>
+#include <QCommandLineParser>
+
+namespace translateLocally {
+
+/**
+ * @brief CLIArgumentInit Inits the command line argument parsing.
+ * @param translateLocallyApp The translateLocally QApplicaiton
+ * @param parser The command line parser.
+ */
+
+static void CLIArgumentInit(QApplication& translateLocallyApp, QCommandLineParser& parser) {
+    parser.setApplicationDescription("A secure translation service that performs translations for you locally, on your own machine.");
+    parser.addHelpOption();
+    parser.addVersionOption();
+    parser.addOption({{"l", "list-models"}, QObject::tr("List available models.")});
+    parser.addOption({{"m", "model"}, QObject::tr("Select model for translation."), "model", ""});
+    parser.addOption({{"s", "source-text"}, QObject::tr("Source translation text (or just used stdin)"), "srctxt", ""});
+    parser.addOption({{"t", "target-text"}, QObject::tr("Target translation output (or just used stdout)"), "trgtxt", ""});
+    parser.process(translateLocallyApp);
+}
+
+/**
+ * @brief isCLIOnly Checks if the application should run in cliONLY mode or launch the GUI
+ * @param parser The command line parser.
+ * @return
+ */
+
+static bool isCLIOnly(QCommandLineParser& parser) {
+    QList<QString> cmdonlyflags = {"m", "l", "s", "t"};
+    bool cliONLY = false;
+    for (auto&& flag : cmdonlyflags) {
+        if (parser.isSet(flag)) {
+            cliONLY = true;
+            break;
+        }
+    }
+    return cliONLY;
+}
+
+} // namespace translateLocally

--- a/src/CLIParsing.h
+++ b/src/CLIParsing.h
@@ -16,8 +16,8 @@ static void CLIArgumentInit(QApplication& translateLocallyApp, QCommandLineParse
     parser.addVersionOption();
     parser.addOption({{"l", "list-models"}, QObject::tr("List available models.")});
     parser.addOption({{"m", "model"}, QObject::tr("Select model for translation."), "model", ""});
-    parser.addOption({{"s", "source-text"}, QObject::tr("Source translation text (or just used stdin)"), "srctxt", ""});
-    parser.addOption({{"t", "target-text"}, QObject::tr("Target translation output (or just used stdout)"), "trgtxt", ""});
+    parser.addOption({{"i", "input"}, QObject::tr("Source translation text (or just used stdin)"), "input", ""});
+    parser.addOption({{"o", "output"}, QObject::tr("Target translation output (or just used stdout)"), "output", ""});
     parser.process(translateLocallyApp);
 }
 
@@ -28,7 +28,7 @@ static void CLIArgumentInit(QApplication& translateLocallyApp, QCommandLineParse
  */
 
 static bool isCLIOnly(QCommandLineParser& parser) {
-    QList<QString> cmdonlyflags = {"m", "l", "s", "t"};
+    QList<QString> cmdonlyflags = {"m", "l", "i", "o"};
     bool cliONLY = false;
     for (auto&& flag : cmdonlyflags) {
         if (parser.isSet(flag)) {

--- a/src/CommandLineIface.cpp
+++ b/src/CommandLineIface.cpp
@@ -1,0 +1,90 @@
+#include "CommandLineIface.h"
+#include <QFile>
+
+
+CommandLineIface::CommandLineIface(QCommandLineParser& parser, QObject * parent) : QObject(parent), eventLoop_(this), parser_(parser), models_(this),
+                                                                                   settings_(this), translator_(new MarianInterface(this)),
+                                                                                   qcin_(stdin), qcout_(stdout), qcerr_(stderr) {
+    connect(translator_, &MarianInterface::error, this, &CommandLineIface::outputError);
+    connect(translator_, &MarianInterface::translationReady, this, &CommandLineIface::outputTranslation);
+}
+
+int CommandLineIface::run() {
+    if (parser_.isSet("l")) {
+        printLocalModels();
+        return 0;
+    } else if (parser_.isSet("m")) {
+        QString model_shortname = parser_.value("model");
+
+        // Try to find our model in the list of models
+        QString modelpath("");
+        for (auto&& model : models_.getInstalledModels()) {
+            if (model.shortName == model_shortname) {
+                modelpath = model.path;
+            }
+        }
+        if (modelpath == "") {
+            qcerr_ << "We could not find a model identified as: " << model_shortname << " . Use translateLocally -l to list available models or use the GUI to download some from the internet.\n";
+            return 1;
+        }
+        // Init the translation model
+        translator_->setModel(modelpath, settings_.marianSettings());
+        doTranslation();
+        return 0;
+    } else {
+        qcerr_ << "We are in command line mode, but there's nothing for us to do. Some control flow mistake maybe?\n";
+        return 2;
+    }
+}
+
+void CommandLineIface::printLocalModels() {
+    QList<Model> localmodels = models_.getInstalledModels();
+    for (auto&& model : localmodels) {
+        qcout_ << model.src << "-" << model.trg << " type: " << model.type << " version: " << model.localversion << "; To invoke do -m " << model.shortName << '\n';
+    }
+}
+
+/* This function is pseudo blocking, via an event loop.*/
+void CommandLineIface::doTranslation() {
+    // Find whether input is stdin or a file
+    QString input;
+    if (parser_.isSet("s")) {
+        QFile inputFile(parser_.value("s"));
+        if (inputFile.open(QIODevice::ReadOnly)) {
+           QTextStream in(&inputFile);
+           input = in.readAll(); // @TODO this should be more complicated batching thingie, but alas. Should work fine with most small inputs.
+                                 // Alternative is to read it line by line but then it would be horribly inefficient as we would lose all batching.
+           inputFile.close();
+        } else {
+            outputError(QString("Couldn't open input file: " + input));
+        }
+    } else {
+        input = qcin_.readAll(); // @TODO again this should do some batching and allow for full cmd usage but I *really* don't want to re-implement marian...
+                                 // Maybe expose the raw marian interface with their batcher, or the service which has some sort of CLI usage.
+    }
+    translator_->translate(input);
+
+    // Start event loop to block unti translation is ready:
+    eventLoop_.exec();
+}
+
+void CommandLineIface::outputError(QString error) {
+    qcerr_ << error << "\n";
+    exit(22);
+}
+
+void CommandLineIface::outputTranslation(Translation output) {
+    // Find whether output is stdin or a file
+    if (parser_.isSet("t")) {
+        QFile outputFile(parser_.value("t"));
+        if (outputFile.open(QIODevice::WriteOnly)) {
+            QTextStream out(&outputFile);
+            out << output.translation();
+        } else {
+            outputError(QString("Couldnl't open output file: " + output));
+        }
+    } else {
+        qcout_ << output.translation();
+    }
+    eventLoop_.exit();
+}

--- a/src/CommandLineIface.cpp
+++ b/src/CommandLineIface.cpp
@@ -48,15 +48,15 @@ void CommandLineIface::printLocalModels() {
 void CommandLineIface::doTranslation() {
     // Find whether input is stdin or a file
     QString input;
-    if (parser_.isSet("s")) {
-        QFile inputFile(parser_.value("s"));
+    if (parser_.isSet("i")) {
+        QFile inputFile(parser_.value("i"));
         if (inputFile.open(QIODevice::ReadOnly)) {
            QTextStream in(&inputFile);
            input = in.readAll(); // @TODO this should be more complicated batching thingie, but alas. Should work fine with most small inputs.
                                  // Alternative is to read it line by line but then it would be horribly inefficient as we would lose all batching.
            inputFile.close();
         } else {
-            outputError(QString("Couldn't open input file: " + input));
+            outputError(QString("Couldn't open input file: " + parser_.value("i")));
         }
     } else {
         input = qcin_.readAll(); // @TODO again this should do some batching and allow for full cmd usage but I *really* don't want to re-implement marian...
@@ -75,13 +75,13 @@ void CommandLineIface::outputError(QString error) {
 
 void CommandLineIface::outputTranslation(Translation output) {
     // Find whether output is stdin or a file
-    if (parser_.isSet("t")) {
-        QFile outputFile(parser_.value("t"));
+    if (parser_.isSet("o")) {
+        QFile outputFile(parser_.value("o"));
         if (outputFile.open(QIODevice::WriteOnly)) {
             QTextStream out(&outputFile);
             out << output.translation();
         } else {
-            outputError(QString("Couldnl't open output file: " + output));
+            outputError(QString("Couldnl't open output file: " + parser_.value("o")));
         }
     } else {
         qcout_ << output.translation();

--- a/src/CommandLineIface.h
+++ b/src/CommandLineIface.h
@@ -28,11 +28,23 @@ private:
     // Event loop that would wait until translation completes
     QEventLoop eventLoop_;
 
-public:
-    CommandLineIface(QCommandLineParser&, QObject * parent = nullptr);
-    int run();
+    // do_once file in and file out
+    QScopedPointer<QFile> infile_;
+    QScopedPointer<QFile> outfile_;
+    QScopedPointer<QTextStream> instream_;
+    QScopedPointer<QTextStream> outstream_;
+
+    static const int constexpr prefetchLines = 320;
+
+    // Functions
     void printLocalModels();
     void doTranslation();
+    inline QString fetchData();
+
+public:
+    CommandLineIface(QCommandLineParser&, QObject * parent = nullptr);
+    ~CommandLineIface();
+    int run();
 
 private slots:
     void outputError(QString error);

--- a/src/CommandLineIface.h
+++ b/src/CommandLineIface.h
@@ -1,0 +1,42 @@
+#ifndef COMMANDLINEIFACE_H
+#define COMMANDLINEIFACE_H
+
+#include <QObject>
+#include <QTextStream>
+#include <QCommandLineParser>
+#include <QPointer>
+#include <QEventLoop>
+#include "ModelManager.h"
+#include "Settings.h"
+#include "MarianInterface.h"
+#include "Translation.h"
+
+class CommandLineIface : public QObject {
+    Q_OBJECT
+private:
+    const QCommandLineParser& parser_;
+
+    ModelManager models_;
+    QTextStream qcin_;
+    QTextStream qcout_;
+    QTextStream qcerr_;
+
+    // Settings and translator:
+    Settings settings_;
+    QPointer<MarianInterface> translator_;
+
+    // Event loop that would wait until translation completes
+    QEventLoop eventLoop_;
+
+public:
+    CommandLineIface(QCommandLineParser&, QObject * parent = nullptr);
+    int run();
+    void printLocalModels();
+    void doTranslation();
+
+private slots:
+    void outputError(QString error);
+    void outputTranslation(Translation output);
+};
+
+#endif // COMMANDLINEIFACE_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,7 +4,8 @@
 #include "Translation.h"
 
 #include <QApplication>
-#include <QCommandLineParser>
+#include "CLIParsing.h"
+#include "CommandLineIface.h"
 
 int main(int argc, char *argv[])
 {
@@ -22,13 +23,18 @@ int main(int argc, char *argv[])
 
     // Command line parsing
     QCommandLineParser parser;
-    parser.setApplicationDescription("A secure translation service that performs translations for you locally, on your own machine.");
-    parser.addHelpOption();
-    parser.addVersionOption();
-    parser.process(translateLocally);
+    translateLocally::CLIArgumentInit(translateLocally, parser);
 
-    // Launch application
-    MainWindow w;
-    w.show();
-    return translateLocally.exec();
+    // Launch application unless we're supposed to be in CLI mode
+    if (translateLocally::isCLIOnly(parser)) {
+        // The CLI is supposed to just do something and then die.
+        // To do that we will just have an object whose constructor as a side
+        // effect will do the thing and die.
+        CommandLineIface CLIiface = CommandLineIface(parser);
+        return CLIiface.run(); // Also takes care of exit codes
+    } else {
+        MainWindow w;
+        w.show();
+        return translateLocally.exec();
+    }
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -27,9 +27,6 @@ int main(int argc, char *argv[])
 
     // Launch application unless we're supposed to be in CLI mode
     if (translateLocally::isCLIOnly(parser)) {
-        // The CLI is supposed to just do something and then die.
-        // To do that we will just have an object whose constructor as a side
-        // effect will do the thing and die.
         CommandLineIface CLIiface = CommandLineIface(parser);
         return CLIiface.run(); // Also takes care of exit codes
     } else {


### PR DESCRIPTION
We had a request do to a simple command line interface. What this does is basically, implement a very basic command line interface that reuses the models and the settings downloaded via the GUI but allows for piping or daisy chaining for pivoting. This will eventually fix #51 
Example usage:
Listing the models:
```
./translateLocally -l
Czech-English type: tiny version: 1; To invoke do -m cs-en-tiny
German-English type: tiny version: 2; To invoke do -m de-en-tiny
English-Czech type: tiny version: 1; To invoke do -m en-cs-tiny
English-German type: tiny version: 2; To invoke do -m en-de-tiny
English-Spanish type: tiny version: 1; To invoke do -m en-es-tiny
```

Translating to a file:
```
./translateLocally --model en-es-tiny -i /tmp/tst -o /tmp/tran
```

Translating from stdin/stdout:
```
echo "Me gustaria comprar la casa verde" | ./translateLocally -m es-en-tiny
I'd like to buy the green house.
```

Pivoting:
```
echo "Me gustaria comprar la casa verde" | ./translateLocally -m es-en-tiny | ./translateLocally -m en-de-tiny
Ich möchte das Gewächshaus kaufen.
```

Major issues.
Batching. Since I didn't want to re-implement marian-decoder with batching, or modify the `marianInterface` in any ways, so I just do a `readAll()`, which won't scale to big files. Maybe users won't use it for big files.  Maybe we should use the service more directly?
Blocking. I'm using a `QEventLoop` to wait for the translation to complete. Maybe we should really not be using the service here..?
Fun thing how a house that is green in Spanish becomes Greenhouse in German...