### PR TITLE
Clean-up of cli code path

### DIFF
--- a/src/CommandLineIface.cpp
+++ b/src/CommandLineIface.cpp
@@ -3,10 +3,9 @@
 
 #include <array>
 
-CommandLineIface::CommandLineIface(QCommandLineParser& parser, QObject * parent)
+CommandLineIface::CommandLineIface(QObject * parent)
 : QObject(parent)
 , eventLoop_(this)
-, parser_(parser)
 , models_(this)
 , settings_(this)
 , translator_(new MarianInterface(this))
@@ -17,34 +16,34 @@ CommandLineIface::CommandLineIface(QCommandLineParser& parser, QObject * parent)
     connect(translator_, &MarianInterface::translationReady, this, &CommandLineIface::outputTranslation);
 }
 
-int CommandLineIface::run() {
-    if (parser_.isSet("l")) {
+int CommandLineIface::run(QCommandLineParser const &parser) {
+    if (parser.isSet("l")) {
         printLocalModels();
         return 0;
-    } else if (parser_.isSet("m")) {
+    } else if (parser.isSet("m")) {
         // Open file as input stream if necessary
-        if (parser_.isSet("i")) {
-            infile_.setFileName(parser_.value("i"));
+        if (parser.isSet("i")) {
+            infile_.setFileName(parser.value("i"));
             if (infile_.open(QIODevice::ReadOnly)) {
                 instream_.setDevice(&infile_);
             } else {
-                qCritical() << "Couldn't open input file:" + parser_.value("i");
+                qCritical() << "Couldn't open input file:" + parser.value("i");
                 return 3;
             }
         }
 
         // Same, but output stream
-        if (parser_.isSet("o")) {
-            outfile_.setFileName(parser_.value("o"));
+        if (parser.isSet("o")) {
+            outfile_.setFileName(parser.value("o"));
             if (outfile_.open(QIODevice::WriteOnly)) {
                 outstream_.setDevice(&outfile_);
             } else {
-                qCritical() << "Couldn't open output file:" + parser_.value("o");
+                qCritical() << "Couldn't open output file:" + parser.value("o");
                 return 4;
             }
         }
 
-        QString model_shortname = parser_.value("model");
+        QString model_shortname = parser.value("model");
 
         // Try to find our model in the list of models
         QString modelpath;

--- a/src/CommandLineIface.cpp
+++ b/src/CommandLineIface.cpp
@@ -3,28 +3,15 @@
 
 #include <array>
 
-CommandLineIface::CommandLineIface(QCommandLineParser& parser, QObject * parent) : QObject(parent), eventLoop_(this), parser_(parser), models_(this),
-                                                                                   settings_(this), translator_(new MarianInterface(this)),
-                                                                                   qcin_(stdin), qcout_(stdout), qcerr_(stderr) {
-    // Initialise input and output streams files if necessary
-    if (parser_.isSet("i")) {
-        infile_.reset(new QFile(parser_.value("i")));
-        if (infile_->open(QIODevice::ReadOnly)) {
-            instream_.reset(new QTextStream(infile_.data()));
-        } else {
-            outputError(QString("Couldn't open input file: " + parser_.value("i")));
-        }
-    }
-
-    if (parser_.isSet("o")) {
-        outfile_.reset(new QFile(parser_.value("o")));
-        if (outfile_->open(QIODevice::WriteOnly)) {
-            outstream_.reset(new QTextStream(outfile_.data()));
-        } else {
-            outputError(QString("Couldn't open output file: " + parser_.value("o")));
-        }
-    }
-
+CommandLineIface::CommandLineIface(QCommandLineParser& parser, QObject * parent)
+: QObject(parent)
+, eventLoop_(this)
+, parser_(parser)
+, models_(this)
+, settings_(this)
+, translator_(new MarianInterface(this))
+, instream_(stdin)
+, outstream_(stdout) {
     // Take care of slots and signals
     connect(translator_, &MarianInterface::error, this, &CommandLineIface::outputError);
     connect(translator_, &MarianInterface::translationReady, this, &CommandLineIface::outputTranslation);
@@ -35,93 +22,93 @@ int CommandLineIface::run() {
         printLocalModels();
         return 0;
     } else if (parser_.isSet("m")) {
+        // Open file as input stream if necessary
+        if (parser_.isSet("i")) {
+            infile_.setFileName(parser_.value("i"));
+            if (infile_.open(QIODevice::ReadOnly)) {
+                instream_.setDevice(&infile_);
+            } else {
+                qCritical() << "Couldn't open input file:" + parser_.value("i");
+                return 3;
+            }
+        }
+
+        // Same, but output stream
+        if (parser_.isSet("o")) {
+            outfile_.setFileName(parser_.value("o"));
+            if (outfile_.open(QIODevice::WriteOnly)) {
+                outstream_.setDevice(&outfile_);
+            } else {
+                qCritical() << "Couldn't open output file:" + parser_.value("o");
+                return 4;
+            }
+        }
+
         QString model_shortname = parser_.value("model");
 
         // Try to find our model in the list of models
-        QString modelpath("");
+        QString modelpath;
         for (auto&& model : models_.getInstalledModels()) {
             if (model.shortName == model_shortname) {
                 modelpath = model.path;
             }
         }
-        if (modelpath == "") {
-            qcerr_ << "We could not find a model identified as: " << model_shortname << " . Use translateLocally -l to list available models or use the GUI to download some from the internet.\n";
+        if (modelpath.isEmpty()) {
+            qCritical() << "We could not find a model identified as:" << model_shortname << ". Use translateLocally -l to list available models or use the GUI to download some from the internet.";
             return 1;
         }
+
         // Init the translation model
         translator_->setModel(modelpath, settings_.marianSettings());
         doTranslation();
         return 0;
     } else {
-        qcerr_ << "We are in command line mode, but there's nothing for us to do. Some control flow mistake maybe?\n";
+        qCritical() << "We are in command line mode, but there's nothing for us to do. Some control flow mistake maybe?";
         return 2;
     }
 }
 
 void CommandLineIface::printLocalModels() {
     QList<Model> localmodels = models_.getInstalledModels();
+    QTextStream out(stdout);
     for (auto&& model : localmodels) {
-        qcout_ << model.src << "-" << model.trg << " type: " << model.type << " version: " << model.localversion << "; To invoke do -m " << model.shortName << '\n';
+        out << model.src << "-" << model.trg << " type: " << model.type << " version: " << model.localversion << "; To invoke do -m " << model.shortName << '\n';
     }
 }
 
-inline QString CommandLineIface::fetchData() {
+QString &CommandLineIface::fetchData(QString &buffer) {
     // Fetch up to prefetchLines number of lines from input
-    QString ret("");
     int counter = 0;
-    if (parser_.isSet("i")) {
-        while(counter < prefetchLines && !instream_->atEnd()) {
-            ret = ret + instream_->readLine() + "\n"; // The new line has no EoL characters
-            counter++;
-        }
-    } else {
-        static std::array<char, 8> inbuff;
-        while (counter < prefetchLines && !qcin_.atEnd()) {
-            ret = ret + qcin_.readLine() + "\n";
-            counter++;
-            if (qcin_.device()->peek(inbuff.data(), 8) == 0) { // This check gets rid of empty new line input
-                break;
-            }
-        }
+    buffer.clear();
+    
+    while(counter < prefetchLines && !instream_.atEnd()) {
+        buffer.append(instream_.readLine());
+        buffer.append('\n'); // The new line has no EoL characters
+        counter++;
     }
-    return ret;
+
+    return buffer;
 }
 
 /* This function is pseudo blocking, via an event loop.*/
 void CommandLineIface::doTranslation() {
-    // Find whether input is stdin or a file
-    QString input = fetchData();
-    while (input != "" && input != "\n") { // Some files end in new line, others don't...
+    QString input;
+    while (!fetchData(input).isEmpty()) {
         translator_->translate(input);
-        // Start event loop to block unti translation is ready:
+        // Start event loop to block unit translation is ready. Translator
+        // will call outputTranslation or outputError during this call, which
+        // will either unblock this exec() call, or kill the program.
         eventLoop_.exec();
-        input = fetchData();
     }
 }
 
 void CommandLineIface::outputError(QString error) {
-    qcerr_ << error << "\n";
-    qcerr_.flush();
+    qCritical() << error;
     exit(22);
 }
 
 void CommandLineIface::outputTranslation(Translation output) {
-    // Find whether output is stdin or a file
-    if (parser_.isSet("o")) {
-        *outstream_.data() << output.translation();
-        outfile_->flush();
-    } else {
-        qcout_ << output.translation();
-        qcout_.flush();
-    }
+    outstream_ << output.translation();
+    outstream_.flush();
     eventLoop_.exit(); // Unblock the main thread
-}
-
-CommandLineIface::~CommandLineIface() {
-    if (parser_.isSet("i")) {
-        infile_->close();
-    }
-    if (parser_.isSet("o")) {
-        outfile_->close();
-    }
 }

--- a/src/CommandLineIface.cpp
+++ b/src/CommandLineIface.cpp
@@ -77,12 +77,12 @@ void CommandLineIface::printLocalModels() {
 }
 
 QString &CommandLineIface::fetchData(QString &buffer) {
-    // Fetch up to prefetchLines number of lines from input
     int counter = 0;
     buffer.clear();
+    static QString line;
     
-    while(counter < prefetchLines && !instream_.atEnd()) {
-        buffer.append(instream_.readLine());
+    while(counter < prefetchLines && instream_.readLineInto(&line)) {
+        buffer.append(line);
         buffer.append('\n'); // The new line has no EoL characters
         counter++;
     }

--- a/src/CommandLineIface.h
+++ b/src/CommandLineIface.h
@@ -17,10 +17,7 @@ private:
     const QCommandLineParser& parser_;
 
     ModelManager models_;
-    QTextStream qcin_;
-    QTextStream qcout_;
-    QTextStream qcerr_;
-
+    
     // Settings and translator:
     Settings settings_;
     QPointer<MarianInterface> translator_;
@@ -29,21 +26,20 @@ private:
     QEventLoop eventLoop_;
 
     // do_once file in and file out
-    QScopedPointer<QFile> infile_;
-    QScopedPointer<QFile> outfile_;
-    QScopedPointer<QTextStream> instream_;
-    QScopedPointer<QTextStream> outstream_;
+    QFile infile_;
+    QFile outfile_;
+    QTextStream instream_;
+    QTextStream outstream_;
 
     static const int constexpr prefetchLines = 320;
 
     // Functions
     void printLocalModels();
     void doTranslation();
-    inline QString fetchData();
+    inline QString &fetchData(QString &);
 
 public:
     CommandLineIface(QCommandLineParser&, QObject * parent = nullptr);
-    ~CommandLineIface();
     int run();
 
 private slots:

--- a/src/CommandLineIface.h
+++ b/src/CommandLineIface.h
@@ -4,7 +4,6 @@
 #include <QObject>
 #include <QTextStream>
 #include <QCommandLineParser>
-#include <QPointer>
 #include <QEventLoop>
 #include "ModelManager.h"
 #include "Settings.h"
@@ -14,8 +13,6 @@
 class CommandLineIface : public QObject {
     Q_OBJECT
 private:
-    const QCommandLineParser& parser_;
-
     ModelManager models_;
     
     // Settings and translator:
@@ -39,8 +36,8 @@ private:
     inline QString &fetchData(QString &);
 
 public:
-    CommandLineIface(QCommandLineParser&, QObject * parent = nullptr);
-    int run();
+    explicit CommandLineIface(QObject * parent = nullptr);
+    int run(QCommandLineParser const &);
 
 private slots:
     void outputError(QString error);

--- a/src/CommandLineIface.h
+++ b/src/CommandLineIface.h
@@ -2,6 +2,7 @@
 #define COMMANDLINEIFACE_H
 
 #include <QObject>
+#include <QPointer>
 #include <QTextStream>
 #include <QCommandLineParser>
 #include <QEventLoop>

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -27,8 +27,7 @@ int main(int argc, char *argv[])
 
     // Launch application unless we're supposed to be in CLI mode
     if (translateLocally::isCLIOnly(parser)) {
-        CommandLineIface CLIiface = CommandLineIface(parser);
-        return CLIiface.run(); // Also takes care of exit codes
+        return CommandLineIface().run(parser); // Also takes care of exit codes
     } else {
         MainWindow w;
         w.show();


### PR DESCRIPTION
While reviewing #58 I noticed that it didn't work well with files with blank lines, which might have been due to the `peek()` call in the `fetchData` method. While digging through documentation to figure out what was going on, I saw a couple of opportunities for improvements.

That if-statement `qcin_.device()->peek(inbuff.data(), 8) == 0` was true after each line on macOS when piping another process into translateLocally, which in term caused `fetchData` to only return single lines. If one of those lines was empty, it returned `\n` which caused translateLocally to stop translating.

Test case:
```
echo -ne "This is a test.\n\nWith an empty line." | ./translateLocally -m en-de-tiny
```

While debugging this (and not hitting the "submit review" button before #58 was merged, sorry!) I also noticed something else that worried me in the `QIODevice::peek()` documentation:
> Note that on sequential devices, data may not be immediately available, which may result in a partial line being returned. By calling the canReadLine() function before reading, you can check whether a complete line (including the newline character) can be read.

So digging further through the documentation, no such warning exists for `QTextStream`, which is already used for file handling. I rewrite the stdin/stdout codepath to use those same streams (it seems you can just alter where they point through after construction using `QTextStream::setDevice()`, ideal!).

While eliminating pointers, I did the same thing for the QFile pointers. The destructor of QFile also guarantees to close them on destruct, so that's cool. I also moved the `exit()` calls from the constructor to `run()` because quitting half-way through a constructor feels scary (although, it's `exit()`, it just kills the program, no proper deconstruction anyway, I suppose)

And then the game was on. So I rewrite `fetchData` to re-use its strings as much as possible, getting the translation time for Crime & Punishment from 42s to 32s when using the `-i` and `-o` options.
