### PR TITLE
Various fixes related to best QT practises

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -193,7 +193,7 @@ set(LINK_LIBRARIES
     ${LibArchive_LIBRARIES}
     ${CMAKE_DL_LIBS}) # On unix necessary sometimes
 
-# Reserver the translateLocally name for the MacOS and Windows (potentially) executables. Rename the unix executable to that
+# Reserve the translateLocally name for the MacOS executables. Rename the Linux and Windows executable to translateLocally after compilation
 target_link_libraries(translateLocally-bin PRIVATE ${LINK_LIBRARIES})
 set_target_properties(translateLocally-bin PROPERTIES OUTPUT_NAME translateLocally)
 

--- a/src/AlignmentHighlighter.cpp
+++ b/src/AlignmentHighlighter.cpp
@@ -55,7 +55,6 @@ void AlignmentHighlighter::render(QVector<WordAlignment> alignments) {
 	// TODO: early stopping based on max(alignments_.last().end alignments.last().end)
 	for (; block != document_->end(); block = block.next()) {
 		QTextLayout *layout = block.layout();
-		QList<QTextFormat> formats;
 		bool dirty = false;
 
 		QVector<QTextLayout::FormatRange> ranges;

--- a/src/ModelManager.cpp
+++ b/src/ModelManager.cpp
@@ -129,7 +129,7 @@ Model ModelManager::writeModel(QFile *file, QString filename) {
     QString newModelDirPath = configDir_.absoluteFilePath(newModelDirName);
 
     if (!QDir().rename(prefix, newModelDirPath)) {
-        emit error(tr("Could not move extracted model from %1 to %2.").arg(tempDir.path()).arg(newModelDirPath));
+        emit error(tr("Could not move extracted model from %1 to %2.").arg(tempDir.path(), newModelDirPath));
         return Model{};
     }
 
@@ -290,7 +290,6 @@ void ModelManager::scanForModels(QString path) {
     //Iterate over all files in the folder and take note of available models and archives
     //@TODO currently, archives can only be extracted from the config dir
     QDirIterator it(path, QDir::NoFilter);
-    QList<Model> models;
     while (it.hasNext()) {
         QString current = it.next();
         QFileInfo f(current);
@@ -334,14 +333,14 @@ bool ModelManager::extractTarGz(QFile *file, QDir const &destination, QStringLis
     QString currentPath = QDir::currentPath();
 
     if (!QDir::setCurrent(destination.absolutePath())) {
-        emit error(tr("Failed to change path to the configuration directory %1. %2 won't be extracted.").arg(destination.absolutePath()).arg(file->fileName()));
+        emit error(tr("Failed to change path to the configuration directory %1. %2 won't be extracted.").arg(destination.absolutePath(), file->fileName()));
         return false;
     }
 
     QStringList extracted;
     bool success = extractTarGzInCurrentPath(file, extracted);
 
-    for (QString const &file : extracted)
+    for (QString const &file : qAsConst(extracted))
         files << destination.filePath(file);
 
     QDir::setCurrent(currentPath);
@@ -350,7 +349,7 @@ bool ModelManager::extractTarGz(QFile *file, QDir const &destination, QStringLis
 
 bool ModelManager::extractTarGzInCurrentPath(QFile *file, QStringList &files) {
     auto warn = [&](const char *f, const char *m) {
-        emit error(tr("Trouble while extracting language model after call to %1: %2").arg(f).arg(m));
+        emit error(tr("Trouble while extracting language model after call to %1: %2").arg(f, m));
     };
 
     auto copy_data = [=](struct archive *a_in, struct archive *a_out) {
@@ -390,7 +389,7 @@ bool ModelManager::extractTarGzInCurrentPath(QFile *file, QStringList &files) {
     archive_read_support_filter_gzip(a_in);
     
     if (!file->open(QIODevice::ReadOnly)) {
-        emit error(tr("Trouble while extracting language model after call to %1: %2").arg("QIODevice::open()").arg(file->errorString()));
+        emit error(tr("Trouble while extracting language model after call to %1: %2").arg("QIODevice::open()", file->errorString()));
         return false;
     }
     
@@ -481,19 +480,19 @@ void ModelManager::parseRemoteModels(QJsonObject obj) {
     updateAvailableModels();
 }
 
-QList<Model> ModelManager::getInstalledModels() const {
+const QList<Model>& ModelManager::getInstalledModels() const {
     return localModels_;
 }
 
-QList<Model> ModelManager::getRemoteModels() const {
+const QList<Model>& ModelManager::getRemoteModels() const {
     return remoteModels_;
 }
 
-QList<Model> ModelManager::getNewModels() const {
+const QList<Model>& ModelManager::getNewModels() const {
     return newModels_;
 }
 
-QList<Model> ModelManager::getUpdatedModels() const {
+const QList<Model>& ModelManager::getUpdatedModels() const {
     return updatedModels_;
 }
 

--- a/src/ModelManager.h
+++ b/src/ModelManager.h
@@ -139,32 +139,32 @@ public:
      * Useful for checking whether a model for which you've saved the path
      * is still available.
      */
-    Model getModelForPath(QString path) const; 
+    Model getModelForPath(QString path) const;
 
     /**
      * @Brief list of locally available models
      */
-    QList<Model> getInstalledModels() const;
+    const QList<Model>& getInstalledModels() const;
 
     /**
      * @Brief list of remotely available models. Only populated after
      * fetchRemoteModels is called and the fetchedRemoteModels() signal is
      * emitted.
      */
-    QList<Model> getRemoteModels() const;
+    const QList<Model>& getRemoteModels() const;
 
     /**
      * @Brief list of models that is both available locally and remote, but
      * the remote version is newer. Only available after fetchRemoteModels().
      */
-    QList<Model> getUpdatedModels() const;
+    const QList<Model>& getUpdatedModels() const;
 
     /**
      * @Brief list of models that is available remote and not also installed
      * locally already. Only available after fetchRemoteModels().
      */
 
-    QList<Model> getNewModels() const;
+    const QList<Model>& getNewModels() const;
     
     /**
      * @brief whether or not fetchRemoteModels is in progress

--- a/src/TranslatorSettingsDialog.cpp
+++ b/src/TranslatorSettingsDialog.cpp
@@ -74,7 +74,7 @@ void TranslatorSettingsDialog::applySettings()
 
 void TranslatorSettingsDialog::revealSelectedModels()
 {
-    for (auto index : ui_->localModelTable->selectionModel()->selectedIndexes()) {
+    for (auto&& index : ui_->localModelTable->selectionModel()->selectedIndexes()) {
         Model model = modelManager_->data(index, Qt::UserRole).value<Model>();
         QDesktopServices::openUrl(QUrl(QString("file://%1").arg(model.path), QUrl::TolerantMode));
     }
@@ -82,8 +82,8 @@ void TranslatorSettingsDialog::revealSelectedModels()
 
 void TranslatorSettingsDialog::deleteSelectedModels()
 {
-    QList<Model> selection;
-    for (auto index : ui_->localModelTable->selectionModel()->selectedRows(0)) {
+    QVector<Model> selection;
+    for (auto&& index : ui_->localModelTable->selectionModel()->selectedRows(0)) {
         Model model = modelManager_->data(index, Qt::UserRole).value<Model>();
         if (modelManager_->isManagedModel(model))
             selection.append(model);
@@ -123,7 +123,7 @@ void TranslatorSettingsDialog::updateModelActions()
     bool containsLocalModel = false;
     bool containsDeletableModel = false;
 
-    for (auto index : ui_->localModelTable->selectionModel()->selectedIndexes()) {
+    for (auto&& index : ui_->localModelTable->selectionModel()->selectedIndexes()) {
         Model model = modelManager_->data(index, Qt::UserRole).value<Model>();
         
         if (model.isLocal())

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -70,7 +70,7 @@ MainWindow::MainWindow(QWidget *parent)
 
     // If no model is preferred, load the first available one.
     if (settings_.translationModel().isEmpty() && !models_.getInstalledModels().empty())
-        settings_.translationModel.setValue(models_.getInstalledModels().first().path);
+        settings_.translationModel.setValue(models_.getInstalledModels().at(0).path);
 
     // Attach slots
     connect(&models_, &ModelManager::error, this, &MainWindow::popupError); // All errors from the model class will be propagated to the GUI
@@ -181,7 +181,7 @@ MainWindow::MainWindow(QWidget *parent)
     });
 
     // Connect changing the highlight colour in settings to updating the highlighter to use it.
-    connect(&settings_.alignmentColor, &Setting::valueChanged, [&](QString name, QVariant color) {
+    connect(&settings_.alignmentColor, &Setting::valueChanged, this, [&](QString name, QVariant color) {
         if (highlighter_)
             highlighter_->setColor(color.value<QColor>());
         // if highlighter_ is not set right now, but will be created later on,
@@ -221,7 +221,7 @@ MainWindow::MainWindow(QWidget *parent)
     bind(settings_.translationModel, std::bind(&MainWindow::resetTranslator, this));
 
     // When input box scrolls, scroll output box as well.
-    connect(ui_->inputBox->verticalScrollBar(), &QAbstractSlider::valueChanged, [&]() {
+    connect(ui_->inputBox->verticalScrollBar(), &QAbstractSlider::valueChanged, this, [&]() {
         if (settings_.syncScrolling())
             ::copyScrollPosition(ui_->inputBox, ui_->outputBox);
     });

--- a/src/types.h
+++ b/src/types.h
@@ -1,5 +1,5 @@
 #pragma once
-
+#include <stddef.h>
 namespace translateLocally {
 
 struct marianSettings {


### PR DESCRIPTION
Hi,

So I followed various QT best practises and fixed couple of things:

Using `arg(A,B)` as opposed to `arg(A).arg(B)`

Making const methods return references for performance reasons  (copy constructor is always invoked) and to prevent C++11 iterators from accidentally creating a const copy of the object to iterate: https://stackoverflow.com/questions/35811053/using-c11-range-based-for-loop-correctly-in-qt https://bugreports.qt.io/browse/QTCREATORBUG-25322

Providing `this` to several lambda based `connect` calls because capturing by reference would mean they might get called when the parent object was destroyed. https://stackoverflow.com/questions/27952902/qobject-context-in-qobjectconnect-function I hope this one will fix the QT warning about null receiver that gets called every once in a while.

Also, removing unused variables and changing some QLists to QVector for QT5 best practises reasons.