### PR TITLE
Be more friendly to first run

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -250,7 +250,7 @@ void MainWindow::showEvent(QShowEvent *ev) {
 void MainWindow::showFirstRunHelper() {
     if (models_.getInstalledModels().isEmpty()) {
         QMessageBox firstRun(QMessageBox::NoIcon, tr("First run"),
-                               tr("Wellcome to translateLocally, our privacy focussed machine translation service!\n\n\
+                               tr("Wellcome to translateLocally, our privacy focussed machine translation system!\n\n\
 It looks like you don't have any translation models currently installed.\n\n\
 Would you like to connect to the Internet to see a list of available translation models?"),
                                QMessageBox::Ok | QMessageBox::Cancel, this);

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -22,6 +22,7 @@
 #include "logo/logo_svg.h"
 #include <iostream>
 #include <QScrollBar>
+#include <QMessageBox>
 
 namespace {
     void addDisabledItem(QComboBox *combobox, QString label) {
@@ -236,6 +237,24 @@ MainWindow::MainWindow(QWidget *parent)
     }, Qt::QueuedConnection);
 }
 
+void MainWindow::showEvent(QShowEvent *ev) {
+    // Once everything is connected, put in first run dialog here
+    QMainWindow::showEvent(ev);
+    QMetaObject::invokeMethod(this, &MainWindow::showFirstRunHelper, Qt::ConnectionType::QueuedConnection);
+}
+
+void MainWindow::showFirstRunHelper() {
+    if (models_.getInstalledModels().isEmpty()) {
+        QMessageBox firstRun(QMessageBox::NoIcon, tr("First run"),
+                               tr("It looks like this is the first time you run translateLocally and you have no translation models installed.\n\nWould you like to connect to the Internet to see a list of available translation models?"),
+                               QMessageBox::Ok | QMessageBox::Cancel, this);
+        int ret = firstRun.exec();
+        if (ret == QMessageBox::Ok) {
+            models_.fetchRemoteModels();
+        }
+    }
+}
+
 MainWindow::~MainWindow() {
     settings_.windowGeometry.setValue(saveGeometry());
     delete ui_;
@@ -391,9 +410,10 @@ void MainWindow::translate(QString const &text) {
     ui_->translateButton->setEnabled(false);
     if (translator_->model().isEmpty()) {
         if (models_.getInstalledModels().isEmpty()) {
-            popupError(tr("You need to download a translation model first. You can do that through the drop down menu on top."));
-        } else {
+            showFirstRunHelper();
+        } else { // TBH I am not sure how we can ever end up in the else branch but better to have it.
             popupError(tr("You need to pick a translation model first. You can do that through the drop down menu on top."));
+            ui_->localModels->showPopup(); // Makes it a bit more intuitive for the user to know what to do
         }
     } else {
         translator_->translate(text);

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -250,7 +250,9 @@ void MainWindow::showEvent(QShowEvent *ev) {
 void MainWindow::showFirstRunHelper() {
     if (models_.getInstalledModels().isEmpty()) {
         QMessageBox firstRun(QMessageBox::NoIcon, tr("First run"),
-                               tr("It looks like this is the first time you run translateLocally and you have no translation models installed.\n\nWould you like to connect to the Internet to see a list of available translation models?"),
+                               tr("Wellcome to translateLocally, our privacy focussed machine translation service!\n\n\
+It looks like you don't have any translation models currently installed.\n\n\
+Would you like to connect to the Internet to see a list of available translation models?"),
                                QMessageBox::Ok | QMessageBox::Cancel, this);
         int ret = firstRun.exec();
         if (ret == QMessageBox::Ok) {

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -250,7 +250,7 @@ void MainWindow::showEvent(QShowEvent *ev) {
 void MainWindow::showFirstRunHelper() {
     if (models_.getInstalledModels().isEmpty()) {
         QMessageBox firstRun(QMessageBox::NoIcon, tr("First run"),
-                               tr("Wellcome to translateLocally, our privacy focussed machine translation system!\n\n\
+                               tr("Welcome to translateLocally, our privacy focussed machine translation system!\n\n\
 It looks like you don't have any translation models currently installed.\n\n\
 Would you like to connect to the Internet to see a list of available translation models?"),
                                QMessageBox::Ok | QMessageBox::Cancel, this);

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -240,7 +240,11 @@ MainWindow::MainWindow(QWidget *parent)
 void MainWindow::showEvent(QShowEvent *ev) {
     // Once everything is connected, put in first run dialog here
     QMainWindow::showEvent(ev);
+#if QT_VERSION < QT_VERSION_CHECK(5, 10, 0)
+    QMetaObject::invokeMethod(this, "showFirstRunHelper", Qt::ConnectionType::QueuedConnection);
+#else
     QMetaObject::invokeMethod(this, &MainWindow::showFirstRunHelper, Qt::ConnectionType::QueuedConnection);
+#endif
 }
 
 void MainWindow::showFirstRunHelper() {

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -68,6 +68,10 @@ private slots:
 
     void updateSelectedModel();
 
+protected: // We use this for first run dialog
+    void showEvent(QShowEvent *ev);
+    void showFirstRunHelper();
+
 private:
     Ui::MainWindow * ui_; // Sadly QTCreator can't do its job if Ui::MainWindow is wrapped inside a smart ptr, so raw pointer it is
 

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -70,7 +70,11 @@ private slots:
 
 protected: // We use this for first run dialog
     void showEvent(QShowEvent *ev);
+#if QT_VERSION < QT_VERSION_CHECK(5, 10, 0)
+    Q_INVOKABLE void showFirstRunHelper();
+#else
     void showFirstRunHelper();
+#endif
 
 private:
     Ui::MainWindow * ui_; // Sadly QTCreator can't do its job if Ui::MainWindow is wrapped inside a smart ptr, so raw pointer it is


### PR DESCRIPTION
This is a stopgap solution to #38 so that the users don't get the ugly error message. Not ideal, but should get the job done until we have a better looking solution.
![Screenshot_20211123_153648](https://user-images.githubusercontent.com/2027221/143054889-063f913b-dcb6-4cf8-8536-8e886bf0ff3f.png)

If the user clicks "ok", a remote model list is fetched and the drop down menu is opened. Nothing happens on Cancel.
@kpu good enough?
