### PR TITLE
Set up and fix bundle signing by making the dmg its own target

### DIFF
--- a/cmake/macdeployqt.cmake
+++ b/cmake/macdeployqt.cmake
@@ -8,15 +8,34 @@ get_target_property(_qmake_executable Qt${QT_VERSION_MAJOR}::qmake IMPORTED_LOCA
 get_filename_component(_qt_bin_dir "${_qmake_executable}" DIRECTORY)
 find_program(MACDEPLOYQT_EXECUTABLE macdeployqt HINTS "${_qt_bin_dir}")
 
+set(APPLE_DEVELOPER_ID "" CACHE STRING "Apple Developer ID used for notarization")
+
 # Add commands that copy the required Qt files to the application bundle
 # represented by the target
 function(macdeployqt target)
-    add_custom_command(TARGET ${target} POST_BUILD
-        COMMAND "${MACDEPLOYQT_EXECUTABLE}"
-            \"${target}.app\"
-            -always-overwrite -dmg
-        COMMENT "Deploying Qt..."
-    )
+    if (DEFINED APPLE_DEVELOPER_ID)
+        add_custom_target(${target}.dmg
+            DEPENDS ${target}
+            BYPRODUCTS ${target}.app
+            COMMAND "${MACDEPLOYQT_EXECUTABLE}"
+                "$<TARGET_FILE_DIR:${target}>/../.."
+                -always-overwrite
+                -dmg
+                -appstore-compliant
+                -sign-for-notarization=${APPLE_DEVELOPER_ID}
+            COMMENT "Deploying Qt and signing bundle for notarization..."
+        )
+    else()
+        add_custom_target(${target}.dmg
+            DEPENDS ${target}
+            BYPRODUCTS ${target}.app
+            COMMAND "${MACDEPLOYQT_EXECUTABLE}"
+                "$<TARGET_FILE_DIR:${target}>/../.."
+                -always-overwrite
+                -dmg
+            COMMENT "Deploying Qt..."
+        )
+    endif()
 endfunction()
 
 mark_as_advanced(MACDEPLOYQT_EXECUTABLE)


### PR DESCRIPTION
Previously signing would (sometimes) fail due to the icon being copied to the bundle after macdeployqt was called.

Note that this is only tested with Qt5 installed through Homebrew on macOS. Homebrew's Qt6 macdeployqt is broken because of how Qt6 is compiled with `@rpath` paths internally. The macdeployqt that is shipped with it can't resolve those correctly.