### PR TITLE
Enable caching

### DIFF
--- a/src/MarianInterface.cpp
+++ b/src/MarianInterface.cpp
@@ -141,11 +141,6 @@ MarianInterface::MarianInterface(QObject *parent)
                         double words = wordCount.get();
                         std::chrono::duration<double> elapsedSeconds = end-start;
                         int translationSpeed = std::ceil(words/elapsedSeconds.count()); // @TODO this could probably be done in the service in the future
-
-                        qDebug() << "Cache stats:"
-                                 << "\n  hits =" << service->cacheStats().hits
-                                 << "\n  misses =" << service->cacheStats().misses;
-                        
                         emit translationReady(Translation(std::move(future.get()), translationSpeed));
                     } else {
                         // TODO: What? Raise error? Set model_ to ""?

--- a/src/MarianInterface.cpp
+++ b/src/MarianInterface.cpp
@@ -102,8 +102,8 @@ MarianInterface::MarianInterface(QObject *parent)
                     // @TODO: don't recreate Service if cpu_threads didn't change?
                     marian::bergamot::AsyncService::Config serviceConfig;
                     serviceConfig.numWorkers = modelChange->settings.cpu_threads;
-                    serviceConfig.cacheEnabled = true;
-                    serviceConfig.cacheSize = 1 << 24;
+                    serviceConfig.cacheEnabled = modelChange->settings.translation_cache;
+                    serviceConfig.cacheSize = kTranslationCacheSize;
                     serviceConfig.cacheMutexBuckets = modelChange->settings.cpu_threads;
                     
                     // Free up old service first (see https://github.com/browsermt/bergamot-translator/issues/290)

--- a/src/MarianInterface.cpp
+++ b/src/MarianInterface.cpp
@@ -9,7 +9,6 @@
 #include <thread>
 #include <chrono>
 #include <QMutexLocker>
-#include <QDebug>
 
 namespace  {
 

--- a/src/MarianInterface.h
+++ b/src/MarianInterface.h
@@ -19,6 +19,8 @@ namespace marian {
 
 struct ModelDescription;
 
+constexpr const size_t kTranslationCacheSize = 1 << 16;
+
 class MarianInterface : public QObject {
     Q_OBJECT
 private:

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -16,13 +16,15 @@ Settings::Settings(QObject *parent)
 , showAlignment(backing_, "show_alignment", false)
 , alignmentColor(backing_, "alignment_color", QColor("#EDD400"))
 , syncScrolling(backing_, "sync_scrolling", true)
-, windowGeometry(backing_, "window_geometry") {
+, windowGeometry(backing_, "window_geometry")
+, cacheTranslations(backing_, "cache_translations", true) {
     //
 }
 
 translateLocally::marianSettings Settings::marianSettings() const {
     return {
         cores.value(),
-        workspace.value()
+        workspace.value(),
+        cacheTranslations.value()
     };
 }

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -93,4 +93,5 @@ public:
     SettingImpl<QColor> alignmentColor;
     SettingImpl<bool> syncScrolling;
     SettingImpl<QByteArray> windowGeometry;
+    SettingImpl<bool> cacheTranslations;
 };

--- a/src/TranslatorSettingsDialog.cpp
+++ b/src/TranslatorSettingsDialog.cpp
@@ -60,6 +60,7 @@ void TranslatorSettingsDialog::updateSettings()
     ui_->showAligmentsCheckbox->setChecked(settings_->showAlignment());
     ui_->alignmentColorButton->setColor(settings_->alignmentColor());
     ui_->syncScrollingCheckbox->setChecked(settings_->syncScrolling());
+    ui_->cacheTranslationsCheckbox->setChecked(settings_->cacheTranslations());
 }
 
 void TranslatorSettingsDialog::applySettings()
@@ -70,6 +71,7 @@ void TranslatorSettingsDialog::applySettings()
     settings_->showAlignment.setValue(ui_->showAligmentsCheckbox->isChecked());
     settings_->alignmentColor.setValue(ui_->alignmentColorButton->color());
     settings_->syncScrolling.setValue(ui_->syncScrollingCheckbox->isChecked());
+    settings_->cacheTranslations.setValue(ui_->cacheTranslationsCheckbox->isChecked());
 }
 
 void TranslatorSettingsDialog::revealSelectedModels()

--- a/src/TranslatorSettingsDialog.ui
+++ b/src/TranslatorSettingsDialog.ui
@@ -133,6 +133,19 @@
             </property>
            </widget>
           </item>
+          <item row="2" column="1">
+           <widget class="QCheckBox" name="cacheTranslationsCheckbox">
+            <property name="toolTip">
+             <string>When enabled, translations of sentences are 
+remembered while the program is running to
+speed up re-translation at the cost of a bit
+of memory.</string>
+            </property>
+            <property name="text">
+             <string>Use translation cache</string>
+            </property>
+           </widget>
+          </item>
          </layout>
         </widget>
        </item>

--- a/src/types.h
+++ b/src/types.h
@@ -5,6 +5,7 @@ namespace translateLocally {
 struct marianSettings {
     size_t cpu_threads;
     size_t workspace;
+    bool translation_cache;
 };
 
 } // namespace translateLocally


### PR DESCRIPTION
bergamot-translator has a cache implementation. This would be really helpful for interactive translations where most of the sentences won't be affected by a local edit.

- [x] Enable cache
- [x] Pick a default cache size [1]
- [x] Make cache configurable [2]

[1] The cache implementation does not do any probing, so if there is a hash collision you get only one of them entries making it into the cache. So a small size means many collisions, since `index = hash(sentence) % size`.

[2]  I'm thinking a drop-down in the prefs that goes from 0 (disabled) to something big, but have options like "2mb" "200mb" etc. Number of entries doesn't tell you much anyway since the implementation does not guarantee that those entries will be used.