### PR TITLE
Rich text formatting

### DIFF
--- a/src/MarianInterface.cpp
+++ b/src/MarianInterface.cpp
@@ -117,9 +117,14 @@ MarianInterface::MarianInterface(QObject *parent)
                     model = std::make_shared<marian::bergamot::TranslationModel>(modelConfig, std::move(bundle), modelChange->settings.cpu_threads);
                 } else if (input) {
                     if (model) {
+                        // Remove the "<!DOCTYPE html>" bit
+                        auto begin = input->find("<html");
+                        input->erase(0, begin);
+
                         std::future<int> wordCount = std::async(countWords, *input); // @TODO we're doing an "unnecessary" string copy here (necessary because we std::move input into service->translate)
 
                         marian::bergamot::ResponseOptions options;
+                        options.HTML = true;
                         options.alignment = true;
                         
                         // Using promise for a translation, and future for waiting

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -16,7 +16,8 @@ Settings::Settings(QObject *parent)
 , showAlignment(backing_, "show_alignment", false)
 , alignmentColor(backing_, "alignment_color", QColor("#EDD400"))
 , syncScrolling(backing_, "sync_scrolling", true)
-, windowGeometry(backing_, "window_geometry") {
+, windowGeometry(backing_, "window_geometry")
+, textFormat(backing_, "text_format", AutoDetect) {
     //
 }
 

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -93,4 +93,12 @@ public:
     SettingImpl<QColor> alignmentColor;
     SettingImpl<bool> syncScrolling;
     SettingImpl<QByteArray> windowGeometry;
+
+    enum TextFormat {
+        PlainText,
+        RichText,
+        AutoDetect // plainText unless it switches to RichText
+    };
+
+    SettingImpl<TextFormat> textFormat;
 };

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -121,7 +121,7 @@ MainWindow::MainWindow(QWidget *parent)
             // can't reach it with cursor keys, but it does show up when you use
             // the scrollbar. So to match the line count better, also add it to
             // the output.
-            ui_->outputBox->setPlainText(translation_.translation() + QString("\n"));
+            ui_->outputBox->setHtml(translation_.translation() + QString("\n"));
         }
 
         // Restore scroll position after it jumped to 0 due to setPlainText.
@@ -231,7 +231,7 @@ MainWindow::MainWindow(QWidget *parent)
     // Note: Using Qt::QueuedConnection seems to make it less jumpy when you enter
     // newlines at the end in the input box. Maybe it gives the input
     // box more time to update its height and its scrollbar to update?
-    connect(ui_->inputBox, &QPlainTextEdit::cursorPositionChanged, this, [&]() {
+    connect(ui_->inputBox, &QTextEdit::cursorPositionChanged, this, [&]() {
         if (settings_.syncScrolling())
             ::copyScrollPosition(ui_->inputBox, ui_->outputBox);
     }, Qt::QueuedConnection);
@@ -408,7 +408,7 @@ void MainWindow::updateSelectedModel() {
 
 
 void MainWindow::translate() {
-    translate(ui_->inputBox->toPlainText());
+    translate(ui_->inputBox->toHtml());
 }
 
 void MainWindow::translate(QString const &text) {

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -50,7 +50,7 @@
          <property name="childrenCollapsible">
           <bool>false</bool>
          </property>
-         <widget class="QPlainTextEdit" name="inputBox">
+         <widget class="QTextEdit" name="inputBox">
           <property name="minimumSize">
            <size>
             <width>0</width>


### PR DESCRIPTION
First steps towards working with text with markup info. End goal is to be able to copy/paste a (part of a) document from Microsoft Word into TranslateLocally, have it translated, and be able to copy/paste the output directly back into Word and be it with the right formatting.

- [x] Maintain markup through translation
  - [x] Expand bergamot-translator to accept xhtml-style self-closing tags :(
- [ ] Toggle between rich text and plain text
- [ ] Have controls/keyboard shortcuts to edit markup (e.g. ctrl + b to make something bold)
- [ ] (Is it just me or is it slow?)