### PR TITLE
Better CLIOnly support in display server-less environments

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -264,7 +264,7 @@ jobs:
     - name: Output test # @TODO some more complicated test, perhaps a unit test
       working-directory: ${{github.workspace}}/build
       shell: bash
-      run: ./translateLocally --version # Can't run normally due to not having X server set up
+      run: ./translateLocally --version
 
     - name: Package # Produce a .deb file using cpack
       working-directory: ${{github.workspace}}/build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -196,7 +196,7 @@ jobs:
     - name: Dependencies  # @TODO should also test qt6, but it's not present yet
       run: |
        sudo apt-get update
-       sudo apt-get install -y xvfb libpcre++-dev qttools5-dev qtbase5-dev libqt5svg5-dev libarchive-dev libpcre2-dev ccache
+       sudo apt-get install -y libpcre++-dev qttools5-dev qtbase5-dev libqt5svg5-dev libarchive-dev libpcre2-dev ccache
       
       # https://software.intel.com/content/www/us/en/develop/articles/installing-intel-free-libs-and-python-apt-repo.html
     - name: Install MKL
@@ -264,7 +264,7 @@ jobs:
     - name: Output test # @TODO some more complicated test, perhaps a unit test
       working-directory: ${{github.workspace}}/build
       shell: bash
-      run: xvfb-run --auto-servernum ./translateLocally --version # Can't run normally due to not having X server set up
+      run: ./translateLocally --version # Can't run normally due to not having X server set up
 
     - name: Package # Produce a .deb file using cpack
       working-directory: ${{github.workspace}}/build

--- a/README.md
+++ b/README.md
@@ -127,31 +127,6 @@ sacrebleu -t wmt13 -l en-es --echo ref > /tmp/es.in
 cat /tmp/es.in | ./translateLocally -m es-en-tiny | ./translateLocally -m en-de-tiny -o /tmp/de.out
 ```
 
-## Using in an environment without a running display server
-translateLocally is built on top of QT, with modules linked in such a way that a display server required in order for the program to start, even if we only use the command line interface, resulting in an error like:
-```bash
-$ ./translateLocally --version
-loaded library "/opt/conda/plugins/platforms/libqxcb.so"
-qt.qpa.xcb: could not connect to display
-qt.qpa.plugin: Could not load the Qt platform plugin "xcb" in "" even though it was found.
-This application failed to start because no Qt platform plugin could be initialized. Reinstalling the application may fix this problem.
-
-Available platform plugins are: eglfs, minimal, minimalegl, offscreen, vnc, webgl, xcb.
-
-Aborted
-```
-To get around this, we can use set `QT_QPA_PLATFORM=offscreen` if we have the `offscreen` plugin:
-```bash
-QT_QPA_PLATFORM=offscreen ./translateLocally --version
-translateLocally v0.0.2+a603422
-```
-OR use `xvfb` to emulate a server.
-```bash
-xvfb-run --auto-servernum ./translateLocally --version
-translateLocally v0.0.2+a603422
-```
-Note that this issue only occurs on Linux, as Windows and Mac (at least to my knowledge) always have an active display even in remote sessions.
-
 # Importing custom models
 translateLocally supports importing custom models. translateLocally uses the [Bergamot](https://github.com/browsermt/marian-dev) fork of [marian](https://github.com/marian-nmt/marian-dev). As such, it supports the vast majority marian models out of the box. You can just train your marian model and place it a directory. 
 ## Basic model import

--- a/src/CLIParsing.h
+++ b/src/CLIParsing.h
@@ -10,7 +10,8 @@ namespace translateLocally {
  * @param parser The command line parser.
  */
 
-static void CLIArgumentInit(QApplication& translateLocallyApp, QCommandLineParser& parser) {
+template<class QAppType>
+static void CLIArgumentInit(QAppType& translateLocallyApp, QCommandLineParser& parser) {
     parser.setApplicationDescription("A secure translation service that performs translations for you locally, on your own machine.");
     parser.addHelpOption();
     parser.addVersionOption();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -17,20 +17,26 @@ int main(int argc, char *argv[])
     qRegisterMetaType<QVector<WordAlignment>>("QVector<WordAlignment>");
     qRegisterMetaType<Translation::Direction>("Translation::Direction");
 
+    // Check for CLIOnly mode. In CLIOnly mode we create QCoreApplication that doesn't require a display plugin.
+    // In case we do not need CLIOnly mode, skip the command line parsing and go straght to the GUI instantiation.
+    {
+        QCoreApplication translateLocally(argc, argv);
+        QCoreApplication::setApplicationName("translateLocally");
+        QCoreApplication::setApplicationVersion(TRANSLATELOCALLY_VERSION_FULL);
+        QCommandLineParser parser;
+        translateLocally::CLIArgumentInit(translateLocally, parser);
+
+        // Launch application unless we're supposed to be in CLI mode
+        if (translateLocally::isCLIOnly(parser)) {
+            return CommandLineIface().run(parser); // Also takes care of exit codes
+        }
+    }
+
     QApplication translateLocally(argc, argv);
     QCoreApplication::setApplicationName("translateLocally");
     QCoreApplication::setApplicationVersion(TRANSLATELOCALLY_VERSION_FULL);
 
-    // Command line parsing
-    QCommandLineParser parser;
-    translateLocally::CLIArgumentInit(translateLocally, parser);
-
-    // Launch application unless we're supposed to be in CLI mode
-    if (translateLocally::isCLIOnly(parser)) {
-        return CommandLineIface().run(parser); // Also takes care of exit codes
-    } else {
-        MainWindow w;
-        w.show();
-        return translateLocally.exec();
-    }
+    MainWindow w;
+    w.show();
+    return translateLocally.exec();
 }


### PR DESCRIPTION
We create a QCoreApplication to do the command line parsing and then run a CLI only application if we are supposed to run a CLIOnly application, else we run a GUI application.

@jelmervdl  how about this. The only thing I am not sure about is skipping the CLI parsing in GUI mode. @jerinphilip that should resolve the issue of needing to specify a QT plugin to run in terminal.