### PR TITLE
Compile for generic x86-64 which is compatible with M1 and M2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,6 +35,9 @@ jobs:
           - name: "macOS Big Sur 11.0 avx"
             os: macos-11.0
             arch: "core-avx-i"
+          - name: "macOS Big Sur 11.0 x86-64"
+            os: macos-11.0
+            arch: "x86-64"
          # avx2 build is not any faster, since the critical codepath (intgemm) already uses the most optimal codepath for the user's PC
          # - name: "macOS Catalina 10.15 avx2"
          #   os: macos-10.15
@@ -117,7 +120,7 @@ jobs:
       # and build directories, but this is only available with CMake 3.13 and higher.  
       # The CMake binaries on the Github Actions machines are (as of this writing) 3.12
       run: |-
-        cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DBUILD_ARCH=${{ matrix.arch }} ${{ env.ccache_cmake }}
+        cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DBUILD_ARCH=${{ matrix.arch }} -DCMAKE_OSX_ARCHITECTURES=x86_64 ${{ env.ccache_cmake }}
         cmake $GITHUB_WORKSPACE -LAH
 
     - name: Build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -120,7 +120,7 @@ jobs:
       # and build directories, but this is only available with CMake 3.13 and higher.  
       # The CMake binaries on the Github Actions machines are (as of this writing) 3.12
       run: |-
-        cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DBUILD_ARCH=${{ matrix.arch }} -DCMAKE_OSX_ARCHITECTURES=x86_64 ${{ env.ccache_cmake }}
+        cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DBUILD_ARCH=${{ matrix.arch }} ${{ env.ccache_cmake }}
         cmake $GITHUB_WORKSPACE -LAH
 
     - name: Build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -178,6 +178,9 @@ jobs:
           - name: "Ubuntu 20.04 avx"
             os: ubuntu-20.04
             arch: "core-avx-i"
+          - name: "Ubuntu 20.04 x86-64"
+            os: ubuntu-20.04
+            arch: "x86-64"
           # avx2 build is not any faster, since the critical codepath (intgemm) already uses the most optimal codepath for the user's PC
           # - name: "Ubuntu 18.04 avx2"
           #   os: ubuntu-18.04
@@ -292,6 +295,9 @@ jobs:
           - name: "Windows 2022 avx"
             os: windows-2022
             arch: "core-avx-i"
+          - name: "Windows 2019 x86-64"
+            os: windows-2019
+            arch: "x86-64"
           # avx2 build is not any faster, since the critical codepath (intgemm) already uses the most optimal codepath for the user's PC
           # - name: "Windows 2019 avx2"
           #   os: windows-2019

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Fast and secure translation on your local machine with a GUI, powered by marian 
 
 ## Downloads
 
-You can download the latest automatic build for Windows, Linux and Mac from the [releases](https://github.com/XapaJIaMnu/translateLocally/releases) github tab or from the [official website](https://translatelocally.com).
+You can download the latest automatic build for Windows, Linux and Mac from the [releases](https://github.com/XapaJIaMnu/translateLocally/releases) github tab or from the [official website](https://translatelocally.com). We also have compatibility builds for Windows and Mac that aim to cover very old hardware and M1.
 
 
 ## Compile from source


### PR DESCRIPTION
Basically taken from https://stackoverflow.com/questions/69803659/what-is-the-proper-way-to-build-for-macos-x86-64-using-cmake-on-apple-m1-arm but I tested a local build with these options and it worked on an M2 Macbook Air.