### PR TITLE
inventory: use standard AppDataLocation for model files

### DIFF
--- a/src/inventory/ModelManager.cpp
+++ b/src/inventory/ModelManager.cpp
@@ -94,7 +94,8 @@ ModelManager::ModelManager(QObject *parent, Settings * settings)
     QDir configDir = QStandardPaths::writableLocation(QStandardPaths::AppConfigLocation);
     QDirIterator configDirIter = QDirIterator(configDir);
     while (configDirIter.hasNext()) {
-        QFileInfo fileInfo = configDirIter.nextFileInfo();
+        configDirIter.next();
+        QFileInfo fileInfo = configDirIter.fileInfo();
         if (fileInfo.isDir() || fileInfo.fileName().endsWith(".tar.gz")) {
             QFile::rename(fileInfo.absoluteFilePath(), appDataDir_.filePath(fileInfo.fileName()));
         }

--- a/src/inventory/ModelManager.cpp
+++ b/src/inventory/ModelManager.cpp
@@ -78,9 +78,7 @@ ModelManager::ModelManager(QObject *parent, Settings * settings)
     , settings_(settings)
     , isFetchingRemoteModels_(false)
 {
-    // Create/Load Settings and create a directory on the first run. Use mock QSEttings, because we want nativeFormat, but we don't want ini on linux.
-    // NativeFormat is not always stored in config dir, whereas ini is always stored. We used the ini format to just get a path to a dir.
-    appDataDir_ = QFileInfo(QSettings(QSettings::IniFormat, QSettings::UserScope, "translateLocally", "translateLocally").fileName()).absoluteDir();
+    appDataDir_ = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
     if (!QDir(appDataDir_).exists()) {
         if (QFileInfo::exists(appDataDir_.absolutePath())) {
             std::cerr << "We want to store data at a directory at: " << appDataDir_.absolutePath().toStdString() << " but a file with the same name exists." << std::endl;

--- a/src/inventory/ModelManager.cpp
+++ b/src/inventory/ModelManager.cpp
@@ -505,8 +505,10 @@ void ModelManager::startupLoad() {
         scanForModels(sharedDir);
     }
 
-    //Iterate over all files in the config folder and take note of available models and archives
+    // Iterate over all files in the app's data folder and take note of available models and archives
     scanForModels(appDataDir_.absolutePath());
+    // Also scan for models located in the app's config directory in previous versions
+    scanForModels(QStandardPaths::writableLocation(QStandardPaths::AppConfigLocation));
     scanForModels(QDir::current().path()); // Scan the current directory for models. @TODO archives found in this folder would not be used
 }
 

--- a/src/inventory/ModelManager.h
+++ b/src/inventory/ModelManager.h
@@ -373,7 +373,7 @@ private:
      */
     bool validateModel(QString path);
 
-    QDir configDir_;
+    QDir appDataDir_;
 
     QStringList archives_; // Only archive name, not full path
     QList<Model> localModels_;


### PR DESCRIPTION
inventory: use standard AppDataLocation for model files

This puts the models in $XDG_DATA_DIR/translateLocally on Linux,
or equivalent user data directories on other platforms.

This avoids putting relatively large files in the config directory,
which may be versioned for user dotfiles.

Github: closes #139