### PR TITLE
readme: more explicit list of build dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,20 @@ make -j5
 ./translateLocally
 ```
 
-Requires `QT>=5 libarchive intel-mkl-static`. We make use of the `QT>=5 network`, `QT>=5 linguisticTool` and `QT>=5 svg` components. Depending on your distro, those may be split in separate package from your QT package (Eg `qt{6/7}-tools-dev`; `qt{5/6}-svg` or `libqt5svg5-dev`). QT6 is fully supported and its use is encouraged. `intel-mkl-static` may be part of `mkl` or `intel-mkl` packages.
+Build dependencies:
+
+- `qt`≥5¹ (components²: `base`, `network`, `linguisticTool`, `svg`)
+- `libarchive`
+- `pcre2`
+- `protobuf`
+- `tcmalloc` (included in `gperftools`)
+- `blas` (provided by `openblas` or `intel-mkl-static`³)
+
+¹ QT6 is fully supported and its use is encouraged.
+
+² Depending on your distro, those may be split in separate package from your QT package. (Eg `qt{6/7}-tools-dev`; `qt{5/6}-svg` or `libqt5svg5-dev`).
+
+³ Faster on Intel CPUs. `intel-mkl-static` may be part of `mkl` or `intel-mkl` packages.
 
 ### Ubuntu 20.04 build dependencies:
 ```bash

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Model English-Estonian type tiny successfully removed.
 ```
 
 ## Listing available models
-The avialble models can be listed with `-l`
+The available models can be listed with `-l`
 ```bash
 ./translateLocally -l
 Czech-English type: tiny version: 1; To invoke do -m cs-en-tiny


### PR DESCRIPTION
It wasn't clear that it could be used without Intel MKL,
using BLAS instead.

Github: relates to #140
