### PR TITLE
inventory: search for models in XDG_DATA_DIRS/translateLocally/models

### DIFF
--- a/src/inventory/ModelManager.cpp
+++ b/src/inventory/ModelManager.cpp
@@ -515,7 +515,7 @@ void ModelManager::startupLoad() {
     // Scan for shared models installed through the system package manager.
     // Those paths should only contain already-extracted models.
     // They should be considered read-only.
-    for (const auto &sharedDir : QStandardPaths::locateAll(QStandardPaths::GenericDataLocation, QString("bergamot/models"), QStandardPaths::LocateDirectory)) {
+    for (const auto &sharedDir : QStandardPaths::locateAll(QStandardPaths::AppDataLocation, QString("models"), QStandardPaths::LocateDirectory)) {
         scanForModels(sharedDir);
     }
 


### PR DESCRIPTION
Instead of XDG_DATA_DIRS/bergamot/models, because not all the models
used by this program are Bergamot ones.

GitHub: closes #151
