### PR TITLE
M1 compat

### DIFF
--- a/cmake/fix_ruy_build.sh
+++ b/cmake/fix_ruy_build.sh
@@ -9,7 +9,7 @@ INCLUDE_PATH=I${SRC_PATH}/3rd_party/bergamot-translator/3rd_party/marian-dev/src
 
 cd ${BUILD_DIR}
 
-# mac grep is different from GNU grep...
+# mac sed is different from GNU sed...
 # Find out the OS
 unameOut="$(uname -s)"
 case "${unameOut}" in

--- a/cmake/fix_ruy_build.sh
+++ b/cmake/fix_ruy_build.sh
@@ -9,7 +9,24 @@ INCLUDE_PATH=I${SRC_PATH}/3rd_party/bergamot-translator/3rd_party/marian-dev/src
 
 cd ${BUILD_DIR}
 
+# mac grep is different from GNU grep...
+# Find out the OS
+unameOut="$(uname -s)"
+case "${unameOut}" in
+        Linux*)     machine=Linux;;
+        Darwin*)    machine=Mac;;
+        CYGWIN*)    machine=Cygwin;;
+        MINGW*)     machine=MinGw;;
+        *)          machine="UNKNOWN:${unameOut}"
+esac
+
 # Remove the extra include path
-grep -R ${INCLUDE_PATH}  | cut -d ":" -f1 | xargs sed -i "s\\-${INCLUDE_PATH}\\\\g"
-# There's a /profiler in one of them that is not captured, so remove it manually
-grep -R " /profiler "  | cut -d ":" -f1 | xargs sed -i "s\\ /profiler \\\\g"
+if [ "$machine" = "Mac" ]; then
+  grep -R ${INCLUDE_PATH}  | cut -d ":" -f1 | xargs sed -i '' -e  "s#-${INCLUDE_PATH}##g"
+  # There's a /profiler in one of them that is not captured, so remove it manually
+  grep -R " /profiler "  | cut -d ":" -f1 | xargs sed -i '' -e "s# /profiler ##g"
+else
+  grep -R ${INCLUDE_PATH}  | cut -d ":" -f1 | xargs sed -i "s\\-${INCLUDE_PATH}\\\\g"
+  # There's a /profiler in one of them that is not captured, so remove it manually
+  grep -R " /profiler "  | cut -d ":" -f1 | xargs sed -i "s\\ /profiler \\\\g"
+fi

--- a/dist/cpu_feature.sh
+++ b/dist/cpu_feature.sh
@@ -20,7 +20,7 @@ if [ "$machine" = "Linux" ]; then
 	elif grep -q ssse3 /proc/cpuinfo; then
 		echo "ssse3"
 	else
-		echo "old_or_non_x86"
+		echo `uname -m`
 	fi
 elif [ "$machine" = "Mac" ]; then
 	if /usr/sbin/sysctl -n machdep.cpu.features machdep.cpu.leaf7_features | grep -q AVX512; then
@@ -32,7 +32,7 @@ elif [ "$machine" = "Mac" ]; then
 	elif /usr/sbin/sysctl -n machdep.cpu.features machdep.cpu.leaf7_features | grep -q SSSE3; then
 		echo "ssse3"
 	else
-		echo "old_or_non_x86"
+		echo `uname -m`
 	fi
 else
 	echo "Unsupported platform"


### PR DESCRIPTION
While our `x86_64` executable works on mac M1, native compilation is broken. This branch will fix it.